### PR TITLE
fix(data): fix double-counting of reports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,9 +41,9 @@ build-image:
 	@command -v $(CONTAINER_RUNTIME) >/dev/null 2>&1 || { echo "Error: $(CONTAINER_RUNTIME) is not installed"; exit 1; }
 	$(CONTAINER_RUNTIME) build -t $(IMAGE_NAME) -f $(CONTAINERFILE) .
 
-# Run tests
+# Run tests (use -p 1 to prevent parallel execution across packages, as tests share the same database)
 test:
-	$(GO) test -cover -v -count=1 ./...
+	$(GO) test -p 1 -cover -v -count=1 ./...
 
 # Run linter (requires golangci-lint)
 lint:

--- a/api/handlers/sources.go
+++ b/api/handlers/sources.go
@@ -1,6 +1,6 @@
 package handlers
 
-// AI-ASSISTED: Bob/2026-02-24
+// AI-ASSISTED: Bob 1.0.0
 // This file contains mock implementations of the Sources API endpoints required
 // for compatibility with the Cost Management Operator.
 //
@@ -10,6 +10,7 @@ package handlers
 // /api/sources/v1.0/source_types [GET]
 import (
 	"net/http"
+
 	"github.com/gin-gonic/gin"
 )
 
@@ -47,7 +48,7 @@ func SourcesHandler() gin.HandlerFunc {
 		c.JSON(http.StatusOK, gin.H{
 			"data": []gin.H{},
 			"meta": gin.H{
-				"count": 1,
+				"count": 0,
 			},
 		})
 	}
@@ -76,7 +77,7 @@ func CreateApplicationHandler() gin.HandlerFunc {
 			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 			return
 		}
-		
+
 		c.JSON(http.StatusCreated, gin.H{
 			"id":                  "mock-app-id",
 			"source_id":           body["source_id"],
@@ -92,7 +93,7 @@ func CreateSourceHandler() gin.HandlerFunc {
 			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 			return
 		}
-		
+
 		c.JSON(http.StatusCreated, gin.H{
 			"id":             "mock-source-id",
 			"name":           body["name"],

--- a/internal/db/repository.go
+++ b/internal/db/repository.go
@@ -97,13 +97,13 @@ func (r *Repository) UpsertPod(clusterID, nodeID uuid.UUID, name, namespace, com
 func (r *Repository) InsertPodMetric(podID uuid.UUID, timestamp time.Time, podUsage, podRequest, nodeCapacityCPUCoreSeconds float64, nodeCapacityCPUCores int) error {
 	_, err := r.db.Exec(context.Background(),
 		`INSERT INTO pod_metrics (
-			pod_id, timestamp, pod_usage_cpu_core_seconds, 
-			pod_request_cpu_core_seconds, node_capacity_cpu_core_seconds, 
+			pod_id, timestamp, pod_usage_cpu_core_seconds,
+			pod_request_cpu_core_seconds, node_capacity_cpu_core_seconds,
 			node_capacity_cpu_cores
 		) VALUES ($1, $2, $3, $4, $5, $6)
 		 ON CONFLICT (pod_id, timestamp) DO UPDATE
-		 SET pod_usage_cpu_core_seconds = pod_metrics.pod_usage_cpu_core_seconds + EXCLUDED.pod_usage_cpu_core_seconds,
-		     pod_request_cpu_core_seconds = pod_metrics.pod_request_cpu_core_seconds + EXCLUDED.pod_request_cpu_core_seconds,
+		 SET pod_usage_cpu_core_seconds = EXCLUDED.pod_usage_cpu_core_seconds,
+		     pod_request_cpu_core_seconds = EXCLUDED.pod_request_cpu_core_seconds,
 		     node_capacity_cpu_core_seconds = EXCLUDED.node_capacity_cpu_core_seconds,
 		     node_capacity_cpu_cores = EXCLUDED.node_capacity_cpu_cores`,
 		podID, timestamp, podUsage, podRequest, nodeCapacityCPUCoreSeconds, nodeCapacityCPUCores)
@@ -121,6 +121,20 @@ func (r *Repository) UpdatePodDailySummary(podID uuid.UUID, timestamp time.Time,
 		     total_pod_effective_core_seconds = pod_daily_summary.total_pod_effective_core_seconds + EXCLUDED.total_pod_effective_core_seconds,
 		     total_hours = pod_daily_summary.total_hours + 1`,
 		podID, date, podEffectiveCoreUsage, podEffectiveCoreSeconds)
+	return err
+}
+
+func (r *Repository) UpdatePodDailySummaryWithHours(podID uuid.UUID, date time.Time, maxCoresUsed, totalPodEffectiveCoreSeconds float64, hourCount int) error {
+	dateOnly := date.Truncate(24 * time.Hour)
+	_, err := r.db.Exec(context.Background(),
+		`INSERT INTO pod_daily_summary (
+			pod_id, date, max_cores_used, total_pod_effective_core_seconds, total_hours
+		) VALUES ($1, $2, $3, $4, $5)
+		 ON CONFLICT (pod_id, date) DO UPDATE
+		 SET max_cores_used = GREATEST(pod_daily_summary.max_cores_used, EXCLUDED.max_cores_used),
+		     total_pod_effective_core_seconds = pod_daily_summary.total_pod_effective_core_seconds + EXCLUDED.total_pod_effective_core_seconds,
+		     total_hours = pod_daily_summary.total_hours + EXCLUDED.total_hours`,
+		podID, dateOnly, maxCoresUsed, totalPodEffectiveCoreSeconds, hourCount)
 	return err
 }
 

--- a/internal/db/repository.go
+++ b/internal/db/repository.go
@@ -71,14 +71,13 @@ func (r *Repository) InsertNodeMetric(nodeID uuid.UUID, timestamp time.Time, cor
 	return err
 }
 
-func (r *Repository) UpdateNodeDailySummary(nodeID uuid.UUID, timestamp time.Time, coreCount int) error {
-	date := timestamp.Truncate(24 * time.Hour)
+func (r *Repository) UpdateNodeDailySummary(nodeID uuid.UUID, dateStr string, coreCount, hourCount int) error {
 	_, err := r.db.Exec(context.Background(),
 		`INSERT INTO node_daily_summary (node_id, date, core_count, total_hours)
-		 VALUES ($1, $2, $3, 1)
+		 VALUES ($1, $2, $3, $4)
 		 ON CONFLICT (node_id, date, core_count)
-		 DO UPDATE SET total_hours = node_daily_summary.total_hours + 1`,
-		nodeID, date, coreCount)
+		 DO UPDATE SET total_hours = GREATEST(node_daily_summary.total_hours, EXCLUDED.total_hours)`,
+		nodeID, dateStr, coreCount, hourCount)
 	return err
 }
 
@@ -110,31 +109,16 @@ func (r *Repository) InsertPodMetric(podID uuid.UUID, timestamp time.Time, podUs
 	return err
 }
 
-func (r *Repository) UpdatePodDailySummary(podID uuid.UUID, timestamp time.Time, podEffectiveCoreSeconds, podEffectiveCoreUsage float64) error {
-	date := timestamp.Truncate(24 * time.Hour)
-	_, err := r.db.Exec(context.Background(),
-		`INSERT INTO pod_daily_summary (
-			pod_id, date, max_cores_used, total_pod_effective_core_seconds, total_hours
-		) VALUES ($1, $2, $3, $4, 1)
-		 ON CONFLICT (pod_id, date) DO UPDATE
-		 SET max_cores_used = GREATEST(pod_daily_summary.max_cores_used, EXCLUDED.max_cores_used),
-		     total_pod_effective_core_seconds = pod_daily_summary.total_pod_effective_core_seconds + EXCLUDED.total_pod_effective_core_seconds,
-		     total_hours = pod_daily_summary.total_hours + 1`,
-		podID, date, podEffectiveCoreUsage, podEffectiveCoreSeconds)
-	return err
-}
-
-func (r *Repository) UpdatePodDailySummaryWithHours(podID uuid.UUID, date time.Time, maxCoresUsed, totalPodEffectiveCoreSeconds float64, hourCount int) error {
-	dateOnly := date.Truncate(24 * time.Hour)
+func (r *Repository) UpdatePodDailySummary(podID uuid.UUID, dateStr string, maxCoresUsed, totalPodEffectiveCoreSeconds float64, hourCount int) error {
 	_, err := r.db.Exec(context.Background(),
 		`INSERT INTO pod_daily_summary (
 			pod_id, date, max_cores_used, total_pod_effective_core_seconds, total_hours
 		) VALUES ($1, $2, $3, $4, $5)
 		 ON CONFLICT (pod_id, date) DO UPDATE
 		 SET max_cores_used = GREATEST(pod_daily_summary.max_cores_used, EXCLUDED.max_cores_used),
-		     total_pod_effective_core_seconds = pod_daily_summary.total_pod_effective_core_seconds + EXCLUDED.total_pod_effective_core_seconds,
-		     total_hours = pod_daily_summary.total_hours + EXCLUDED.total_hours`,
-		podID, dateOnly, maxCoresUsed, totalPodEffectiveCoreSeconds, hourCount)
+		     total_pod_effective_core_seconds = EXCLUDED.total_pod_effective_core_seconds,
+		     total_hours = GREATEST(pod_daily_summary.total_hours, EXCLUDED.total_hours)`,
+		podID, dateStr, maxCoresUsed, totalPodEffectiveCoreSeconds, hourCount)
 	return err
 }
 

--- a/internal/db/repository_test.go
+++ b/internal/db/repository_test.go
@@ -12,9 +12,7 @@ import (
 )
 
 func TestUpsertNode(t *testing.T) {
-	pool, newTx := testutils.SetupTestDB(t)
-	tx := newTx()
-	defer tx.Rollback(context.Background())
+	pool, _ := testutils.SetupTestDB(t)
 
 	repo := NewRepository(pool)
 
@@ -23,14 +21,13 @@ func TestUpsertNode(t *testing.T) {
 	identifier := "i-09ad6102842b9a786"
 	nodeRole := "worker"
 
-	time.Sleep(500 * time.Millisecond)
 	nodeID, err := repo.UpsertNode(clusterID, nodeName, identifier, nodeRole)
 	assert.NoError(t, err)
 	assert.NotEqual(t, uuid.Nil, nodeID)
-	time.Sleep(500 * time.Millisecond)
 
+	// Verify the node was created using the pool
 	var count int
-	err = tx.QueryRow(context.Background(), "SELECT COUNT(*) FROM nodes WHERE id = $1", nodeID).Scan(&count)
+	err = pool.QueryRow(context.Background(), "SELECT COUNT(*) FROM nodes WHERE id = $1", nodeID).Scan(&count)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, count)
 }
@@ -51,10 +48,9 @@ func TestInsertNodeMetric(t *testing.T) {
 	nodeID, err := repo.UpsertNode(clusterID, nodeName, identifier, nodeRole)
 	require.NoError(t, err)
 	time.Sleep(500 * time.Millisecond)
-	now := time.Now().UTC()
-	year, month := now.Year(), now.Month()
 
-	timestamp := time.Date(year, month, 15, 14, 0, 0, 0, time.UTC)
+	// Use fixed date in May 2025 (partition exists for this month)
+	timestamp := time.Date(2025, 5, 15, 14, 0, 0, 0, time.UTC)
 	coreCount := 4
 
 	err = repo.InsertNodeMetric(nodeID, timestamp, coreCount, clusterID)
@@ -82,21 +78,22 @@ func TestUpdateNodeDailySummary(t *testing.T) {
 	nodeID, err := repo.UpsertNode(clusterID, nodeName, identifier, nodeRole)
 	require.NoError(t, err)
 
-	timestamp, _ := time.Parse("2006-01-02 15:04:05 +0000 MST", "2025-05-17 14:00:00 +0000 UTC")
+	dateStr := "2025-05-17"
 	coreCount := 4
+	hourCount := 1
 
-	err = repo.UpdateNodeDailySummary(nodeID, timestamp, coreCount)
+	err = repo.UpdateNodeDailySummary(nodeID, dateStr, coreCount, hourCount)
 	assert.NoError(t, err)
 
 	var totalHours int
-	err = tx.QueryRow(context.Background(), "SELECT total_hours FROM node_daily_summary WHERE node_id = $1 AND date = $2", nodeID, "2025-05-17").Scan(&totalHours)
+	err = tx.QueryRow(context.Background(), "SELECT total_hours FROM node_daily_summary WHERE node_id = $1 AND date = $2", nodeID, dateStr).Scan(&totalHours)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, totalHours)
 }
 
 // Made with Bob 1.0.1
 // TestUpdateNodeDailySummary_NoDoubleAggregation verifies that calling UpdateNodeDailySummary
-// multiple times with the same node_id, date, and core_count correctly increments total_hours
+// multiple times with the same node_id, date, and core_count uses GREATEST for total_hours
 // without double-counting. This tests the fix for the double aggregation issue.
 func TestUpdateNodeDailySummary_NoDoubleAggregation(t *testing.T) {
 	pool, newTx := testutils.SetupTestDB(t)
@@ -114,39 +111,39 @@ func TestUpdateNodeDailySummary_NoDoubleAggregation(t *testing.T) {
 	nodeID, err := repo.UpsertNode(clusterID, nodeName, identifier, nodeRole)
 	require.NoError(t, err)
 
-	timestamp, _ := time.Parse("2006-01-02 15:04:05 +0000 MST", "2025-05-17 14:00:00 +0000 UTC")
+	dateStr := "2025-05-17"
 	coreCount := 4
 
 	// First update - should create entry with total_hours = 1
-	err = repo.UpdateNodeDailySummary(nodeID, timestamp, coreCount)
+	err = repo.UpdateNodeDailySummary(nodeID, dateStr, coreCount, 1)
 	require.NoError(t, err)
 
 	var totalHours int
 	err = tx.QueryRow(context.Background(),
 		"SELECT total_hours FROM node_daily_summary WHERE node_id = $1 AND date = $2 AND core_count = $3",
-		nodeID, "2025-05-17", coreCount).Scan(&totalHours)
+		nodeID, dateStr, coreCount).Scan(&totalHours)
 	require.NoError(t, err)
 	assert.Equal(t, 1, totalHours, "First update should set total_hours to 1")
 
-	// Second update with same parameters - should increment to 2
-	err = repo.UpdateNodeDailySummary(nodeID, timestamp, coreCount)
+	// Second update with same parameters - should keep at 1 (using GREATEST, not adding)
+	err = repo.UpdateNodeDailySummary(nodeID, dateStr, coreCount, 1)
 	require.NoError(t, err)
 
 	err = tx.QueryRow(context.Background(),
 		"SELECT total_hours FROM node_daily_summary WHERE node_id = $1 AND date = $2 AND core_count = $3",
-		nodeID, "2025-05-17", coreCount).Scan(&totalHours)
+		nodeID, dateStr, coreCount).Scan(&totalHours)
 	require.NoError(t, err)
-	assert.Equal(t, 2, totalHours, "Second update should increment total_hours to 2")
+	assert.Equal(t, 1, totalHours, "Second update should keep total_hours at 1 (not 2)")
 
-	// Third update - should increment to 3
-	err = repo.UpdateNodeDailySummary(nodeID, timestamp, coreCount)
+	// Third update with more hours - should update to 3
+	err = repo.UpdateNodeDailySummary(nodeID, dateStr, coreCount, 3)
 	require.NoError(t, err)
 
 	err = tx.QueryRow(context.Background(),
 		"SELECT total_hours FROM node_daily_summary WHERE node_id = $1 AND date = $2 AND core_count = $3",
-		nodeID, "2025-05-17", coreCount).Scan(&totalHours)
+		nodeID, dateStr, coreCount).Scan(&totalHours)
 	require.NoError(t, err)
-	assert.Equal(t, 3, totalHours, "Third update should increment total_hours to 3")
+	assert.Equal(t, 3, totalHours, "Third update should set total_hours to 3 (GREATEST of 1 and 3)")
 }
 
 // Made with Bob 1.0.1
@@ -167,14 +164,14 @@ func TestUpdateNodeDailySummary_DifferentCoreCountsSameDay(t *testing.T) {
 	nodeID, err := repo.UpsertNode(clusterID, nodeName, identifier, nodeRole)
 	require.NoError(t, err)
 
-	timestamp, _ := time.Parse("2006-01-02 15:04:05 +0000 MST", "2025-05-17 14:00:00 +0000 UTC")
+	dateStr := "2025-05-17"
 
 	// Update with core_count = 4
-	err = repo.UpdateNodeDailySummary(nodeID, timestamp, 4)
+	err = repo.UpdateNodeDailySummary(nodeID, dateStr, 4, 1)
 	require.NoError(t, err)
 
 	// Update with core_count = 8
-	err = repo.UpdateNodeDailySummary(nodeID, timestamp, 8)
+	err = repo.UpdateNodeDailySummary(nodeID, dateStr, 8, 1)
 	require.NoError(t, err)
 
 	// Verify two separate entries exist
@@ -251,11 +248,9 @@ func TestInsertPodMetric(t *testing.T) {
 	// Insert pod to satisfy foreign key constraint
 	podID, err := repo.UpsertPod(clusterID, nodeID, podName, namespace, component)
 	require.NoError(t, err)
-	now := time.Now().UTC()
-	year, month := now.Year(), now.Month()
 
-	// Pick a day in this month
-	timestamp := time.Date(year, month, 15, 14, 0, 0, 0, time.UTC)
+	// Use fixed date in May 2025 (partition exists for this month)
+	timestamp := time.Date(2025, 5, 15, 14, 0, 0, 0, time.UTC)
 
 	usage := 100.0
 	request := 200.0
@@ -297,9 +292,8 @@ func TestInsertPodMetric_NoDoubleAggregation(t *testing.T) {
 	podID, err := repo.UpsertPod(clusterID, nodeID, podName, namespace, component)
 	require.NoError(t, err)
 
-	now := time.Now().UTC()
-	year, month := now.Year(), now.Month()
-	timestamp := time.Date(year, month, 15, 14, 0, 0, 0, time.UTC)
+	// Use fixed date in May 2025 (partition exists for this month)
+	timestamp := time.Date(2025, 5, 15, 14, 0, 0, 0, time.UTC)
 
 	// First insert
 	usage1 := 100.0
@@ -369,11 +363,11 @@ func TestUpdatePodDailySummary(t *testing.T) {
 	podID, err := repo.UpsertPod(clusterID, nodeID, podName, namespace, component)
 	require.NoError(t, err)
 
-	timestamp, _ := time.Parse("2006-01-02 15:04:05 +0000 MST", "2025-05-17 14:00:00 +0000 UTC")
+	dateStr := "2025-05-17"
 	effectiveCoreSeconds := 200.0
 	coreUsage := 0.013888 // 200 / 14400
 
-	err = repo.UpdatePodDailySummary(podID, timestamp, effectiveCoreSeconds, coreUsage)
+	err = repo.UpdatePodDailySummary(podID, dateStr, coreUsage, effectiveCoreSeconds, 1)
 	assert.NoError(t, err)
 
 	var totalHours int
@@ -412,12 +406,12 @@ func TestUpdatePodDailySummary_NoDoubleAggregation(t *testing.T) {
 	podID, err := repo.UpsertPod(clusterID, nodeID, podName, namespace, component)
 	require.NoError(t, err)
 
-	timestamp, _ := time.Parse("2006-01-02 15:04:05 +0000 MST", "2025-05-17 14:00:00 +0000 UTC")
+	dateStr := "2025-05-17"
 	effectiveCoreSeconds := 200.0
 	coreUsage := 0.013888
 
 	// First update - should create entry with total_hours = 1, total_pod_effective_core_seconds = 200.0
-	err = repo.UpdatePodDailySummary(podID, timestamp, effectiveCoreSeconds, coreUsage)
+	err = repo.UpdatePodDailySummary(podID, dateStr, coreUsage, effectiveCoreSeconds, 1)
 	require.NoError(t, err)
 
 	var totalHours int
@@ -425,36 +419,176 @@ func TestUpdatePodDailySummary_NoDoubleAggregation(t *testing.T) {
 	var maxCoresUsed float64
 	err = tx.QueryRow(context.Background(),
 		"SELECT total_hours, total_pod_effective_core_seconds, max_cores_used FROM pod_daily_summary WHERE pod_id = $1 AND date = $2",
-		podID, "2025-05-17").Scan(&totalHours, &totalEffectiveCoreSeconds, &maxCoresUsed)
+		podID, dateStr).Scan(&totalHours, &totalEffectiveCoreSeconds, &maxCoresUsed)
 	require.NoError(t, err)
 	assert.Equal(t, 1, totalHours, "First update should set total_hours to 1")
 	assert.InDelta(t, 200.0, totalEffectiveCoreSeconds, 0.001, "First update should set total_pod_effective_core_seconds to 200.0")
 	assert.InDelta(t, 0.013888, maxCoresUsed, 0.000001, "First update should set max_cores_used to 0.013888")
 
-	// Second update with same parameters - should increment total_hours to 2 and add to total_pod_effective_core_seconds
-	err = repo.UpdatePodDailySummary(podID, timestamp, effectiveCoreSeconds, coreUsage)
+	// Second update with same parameters - should keep total_hours at 1 (GREATEST) and REPLACE total_pod_effective_core_seconds
+	err = repo.UpdatePodDailySummary(podID, dateStr, coreUsage, effectiveCoreSeconds, 1)
 	require.NoError(t, err)
 
 	err = tx.QueryRow(context.Background(),
 		"SELECT total_hours, total_pod_effective_core_seconds, max_cores_used FROM pod_daily_summary WHERE pod_id = $1 AND date = $2",
-		podID, "2025-05-17").Scan(&totalHours, &totalEffectiveCoreSeconds, &maxCoresUsed)
+		podID, dateStr).Scan(&totalHours, &totalEffectiveCoreSeconds, &maxCoresUsed)
 	require.NoError(t, err)
-	assert.Equal(t, 2, totalHours, "Second update should increment total_hours to 2")
-	assert.InDelta(t, 400.0, totalEffectiveCoreSeconds, 0.001, "Second update should add to total_pod_effective_core_seconds (200 + 200 = 400)")
+	assert.Equal(t, 1, totalHours, "Second update should keep total_hours at 1 (using GREATEST, not adding)")
+	assert.InDelta(t, 200.0, totalEffectiveCoreSeconds, 0.001, "Second update should REPLACE total_pod_effective_core_seconds (stays at 200, not 400)")
 	assert.InDelta(t, 0.013888, maxCoresUsed, 0.000001, "max_cores_used should remain the same")
 
-	// Third update with higher core usage - should update max_cores_used
+	// Third update with higher core usage and more hours - should update max_cores_used, total_hours, and replace core_seconds
 	higherCoreUsage := 0.025
-	err = repo.UpdatePodDailySummary(podID, timestamp, effectiveCoreSeconds, higherCoreUsage)
+	higherEffectiveCoreSeconds := 300.0
+	err = repo.UpdatePodDailySummary(podID, dateStr, higherCoreUsage, higherEffectiveCoreSeconds, 3)
 	require.NoError(t, err)
 
 	err = tx.QueryRow(context.Background(),
 		"SELECT total_hours, total_pod_effective_core_seconds, max_cores_used FROM pod_daily_summary WHERE pod_id = $1 AND date = $2",
-		podID, "2025-05-17").Scan(&totalHours, &totalEffectiveCoreSeconds, &maxCoresUsed)
+		podID, dateStr).Scan(&totalHours, &totalEffectiveCoreSeconds, &maxCoresUsed)
 	require.NoError(t, err)
-	assert.Equal(t, 3, totalHours, "Third update should increment total_hours to 3")
-	assert.InDelta(t, 600.0, totalEffectiveCoreSeconds, 0.001, "Third update should add to total_pod_effective_core_seconds (400 + 200 = 600)")
+	assert.Equal(t, 3, totalHours, "Third update should set total_hours to 3 (GREATEST of 1 and 3)")
+	assert.InDelta(t, 300.0, totalEffectiveCoreSeconds, 0.001, "Third update should REPLACE total_pod_effective_core_seconds (300, not 500)")
 	assert.InDelta(t, 0.025, maxCoresUsed, 0.000001, "max_cores_used should be updated to the higher value")
+}
+
+// Made with Bob 1.0.1
+// TestUpdatePodDailySummary_IdempotentHourCounting verifies that processing the same
+// CSV data multiple times (e.g., due to re-uploads or overlapping data) does not
+// inflate the total_hours count. This is the fix for the bug where 5 unique hours
+// became 15 hours after processing the same data 3 times.
+func TestUpdatePodDailySummary_IdempotentHourCounting(t *testing.T) {
+	pool, newTx := testutils.SetupTestDB(t)
+	tx := newTx()
+	defer tx.Rollback(context.Background())
+
+	repo := NewRepository(pool)
+
+	clusterID, _ := uuid.Parse("10f5a0f9-223a-41c1-8456-9a3eb0323a99")
+	nodeName := "test-node"
+	identifier := "test-identifier"
+	nodeRole := "worker"
+	podName := "eap74-helloworld-5575bdb44c-mk9j4"
+	namespace := "eap74"
+	component := "EAP"
+
+	// Create node and pod
+	nodeID, err := repo.UpsertNode(clusterID, nodeName, identifier, nodeRole)
+	require.NoError(t, err)
+
+	podID, err := repo.UpsertPod(clusterID, nodeID, podName, namespace, component)
+	require.NoError(t, err)
+
+	dateStr := "2026-03-30"
+	effectiveCoreSeconds := 963.264898
+	maxCoreUsage := 0.0018430536805555554
+
+	// Simulate first CSV upload with 5 unique hours of data
+	err = repo.UpdatePodDailySummary(podID, dateStr, maxCoreUsage, effectiveCoreSeconds, 5)
+	require.NoError(t, err)
+
+	var totalHours int
+	var totalEffectiveCoreSeconds float64
+	err = tx.QueryRow(context.Background(),
+		"SELECT total_hours, total_pod_effective_core_seconds FROM pod_daily_summary WHERE pod_id = $1 AND date = $2",
+		podID, dateStr).Scan(&totalHours, &totalEffectiveCoreSeconds)
+	require.NoError(t, err)
+	assert.Equal(t, 5, totalHours, "First upload: should have 5 hours")
+	assert.InDelta(t, 963.264898, totalEffectiveCoreSeconds, 0.001, "First upload: correct core seconds")
+
+	// Simulate second CSV upload with the SAME 5 hours (overlapping data)
+	// This should NOT increase total_hours (should use GREATEST, not add)
+	// Core seconds should be REPLACED (not added) to prevent inflation
+	err = repo.UpdatePodDailySummary(podID, dateStr, maxCoreUsage, effectiveCoreSeconds, 5)
+	require.NoError(t, err)
+
+	err = tx.QueryRow(context.Background(),
+		"SELECT total_hours, total_pod_effective_core_seconds FROM pod_daily_summary WHERE pod_id = $1 AND date = $2",
+		podID, dateStr).Scan(&totalHours, &totalEffectiveCoreSeconds)
+	require.NoError(t, err)
+	assert.Equal(t, 5, totalHours, "Second upload: should STILL have 5 hours (not 10)")
+	assert.InDelta(t, 963.264898, totalEffectiveCoreSeconds, 0.001, "Second upload: core seconds should be REPLACED (stays at 963, not 1926)")
+
+	// Simulate third CSV upload with the SAME 5 hours
+	// Before the fix, this would result in 15 hours (5+5+5) and 2889 core-seconds
+	// After the fix, it should remain 5 hours and 963 core-seconds
+	err = repo.UpdatePodDailySummary(podID, dateStr, maxCoreUsage, effectiveCoreSeconds, 5)
+	require.NoError(t, err)
+
+	err = tx.QueryRow(context.Background(),
+		"SELECT total_hours, total_pod_effective_core_seconds FROM pod_daily_summary WHERE pod_id = $1 AND date = $2",
+		podID, dateStr).Scan(&totalHours, &totalEffectiveCoreSeconds)
+	require.NoError(t, err)
+	assert.Equal(t, 5, totalHours, "Third upload: should STILL have 5 hours (not 15) - THIS IS THE BUG FIX")
+	assert.InDelta(t, 963.264898, totalEffectiveCoreSeconds, 0.001, "Third upload: core seconds should STILL be 963 (not 2889) - THIS IS THE BUG FIX")
+
+	// Now simulate a legitimate update with MORE hours (e.g., new data arrived)
+	newEffectiveCoreSeconds := 1200.0
+	err = repo.UpdatePodDailySummary(podID, dateStr, maxCoreUsage, newEffectiveCoreSeconds, 7)
+	require.NoError(t, err)
+
+	err = tx.QueryRow(context.Background(),
+		"SELECT total_hours, total_pod_effective_core_seconds FROM pod_daily_summary WHERE pod_id = $1 AND date = $2",
+		podID, dateStr).Scan(&totalHours, &totalEffectiveCoreSeconds)
+	require.NoError(t, err)
+	assert.Equal(t, 7, totalHours, "Fourth upload: should update to 7 hours (GREATEST of 5 and 7)")
+	assert.InDelta(t, 1200.0, totalEffectiveCoreSeconds, 0.001, "Fourth upload: core seconds should be REPLACED with new value (1200)")
+}
+
+// Made with Bob 1.0.1
+// TestUpdateNodeDailySummary_IdempotentHourCounting verifies the same idempotent
+// behavior for node metrics
+func TestUpdateNodeDailySummary_IdempotentHourCounting(t *testing.T) {
+	pool, newTx := testutils.SetupTestDB(t)
+	tx := newTx()
+	defer tx.Rollback(context.Background())
+
+	repo := NewRepository(pool)
+
+	clusterID, _ := uuid.Parse("10f5a0f9-223a-41c1-8456-9a3eb0323a99")
+	nodeName := "worker-node-1"
+	identifier := "i-1234567890"
+	nodeRole := "worker"
+
+	// Create node
+	nodeID, err := repo.UpsertNode(clusterID, nodeName, identifier, nodeRole)
+	require.NoError(t, err)
+
+	dateStr := "2026-03-30"
+	coreCount := 12
+
+	// First upload: 4 unique hours
+	err = repo.UpdateNodeDailySummary(nodeID, dateStr, coreCount, 4)
+	require.NoError(t, err)
+
+	var totalHours int
+	err = tx.QueryRow(context.Background(),
+		"SELECT total_hours FROM node_daily_summary WHERE node_id = $1 AND date = $2 AND core_count = $3",
+		nodeID, dateStr, coreCount).Scan(&totalHours)
+	require.NoError(t, err)
+	assert.Equal(t, 4, totalHours, "First upload: should have 4 hours")
+
+	// Second upload: same 4 hours (overlapping data)
+	// Before fix: would become 8 hours (4+4)
+	// After fix: should remain 4 hours
+	err = repo.UpdateNodeDailySummary(nodeID, dateStr, coreCount, 4)
+	require.NoError(t, err)
+
+	err = tx.QueryRow(context.Background(),
+		"SELECT total_hours FROM node_daily_summary WHERE node_id = $1 AND date = $2 AND core_count = $3",
+		nodeID, dateStr, coreCount).Scan(&totalHours)
+	require.NoError(t, err)
+	assert.Equal(t, 4, totalHours, "Second upload: should STILL have 4 hours (not 8) - THIS IS THE BUG FIX")
+
+	// Third upload: more hours (legitimate new data)
+	err = repo.UpdateNodeDailySummary(nodeID, dateStr, coreCount, 6)
+	require.NoError(t, err)
+
+	err = tx.QueryRow(context.Background(),
+		"SELECT total_hours FROM node_daily_summary WHERE node_id = $1 AND date = $2 AND core_count = $3",
+		nodeID, dateStr, coreCount).Scan(&totalHours)
+	require.NoError(t, err)
+	assert.Equal(t, 6, totalHours, "Third upload: should update to 6 hours (GREATEST of 4 and 6)")
 }
 
 // Made with Bob 1.0.1
@@ -481,21 +615,21 @@ func TestUpdatePodDailySummary_MaxCoresUsedTracking(t *testing.T) {
 	podID, err := repo.UpsertPod(clusterID, nodeID, podName, namespace, component)
 	require.NoError(t, err)
 
-	timestamp, _ := time.Parse("2006-01-02 15:04:05 +0000 MST", "2025-05-17 14:00:00 +0000 UTC")
+	dateStr := "2025-05-17"
 
 	// Update with increasing core usage values
 	coreUsageValues := []float64{0.01, 0.05, 0.03, 0.08, 0.02}
 	effectiveCoreSeconds := 200.0
 
 	for _, coreUsage := range coreUsageValues {
-		err = repo.UpdatePodDailySummary(podID, timestamp, effectiveCoreSeconds, coreUsage)
+		err = repo.UpdatePodDailySummary(podID, dateStr, coreUsage, effectiveCoreSeconds, 1)
 		require.NoError(t, err)
 	}
 
 	var maxCoresUsed float64
 	err = tx.QueryRow(context.Background(),
 		"SELECT max_cores_used FROM pod_daily_summary WHERE pod_id = $1 AND date = $2",
-		podID, "2025-05-17").Scan(&maxCoresUsed)
+		podID, dateStr).Scan(&maxCoresUsed)
 	require.NoError(t, err)
 	assert.InDelta(t, 0.08, maxCoresUsed, 0.000001, "max_cores_used should be the maximum value (0.08)")
 }
@@ -524,17 +658,17 @@ func TestUpdatePodDailySummary_DifferentDays(t *testing.T) {
 	podID, err := repo.UpsertPod(clusterID, nodeID, podName, namespace, component)
 	require.NoError(t, err)
 
-	timestamp1, _ := time.Parse("2006-01-02 15:04:05 +0000 MST", "2025-05-17 14:00:00 +0000 UTC")
-	timestamp2, _ := time.Parse("2006-01-02 15:04:05 +0000 MST", "2025-05-18 14:00:00 +0000 UTC")
+	dateStr1 := "2025-05-17"
+	dateStr2 := "2025-05-18"
 	effectiveCoreSeconds := 200.0
 	coreUsage := 0.013888
 
 	// Update for day 1
-	err = repo.UpdatePodDailySummary(podID, timestamp1, effectiveCoreSeconds, coreUsage)
+	err = repo.UpdatePodDailySummary(podID, dateStr1, coreUsage, effectiveCoreSeconds, 1)
 	require.NoError(t, err)
 
 	// Update for day 2
-	err = repo.UpdatePodDailySummary(podID, timestamp2, effectiveCoreSeconds, coreUsage)
+	err = repo.UpdatePodDailySummary(podID, dateStr2, coreUsage, effectiveCoreSeconds, 1)
 	require.NoError(t, err)
 
 	// Verify two separate entries exist

--- a/internal/db/repository_test.go
+++ b/internal/db/repository_test.go
@@ -94,6 +94,112 @@ func TestUpdateNodeDailySummary(t *testing.T) {
 	assert.Equal(t, 1, totalHours)
 }
 
+// Made with Bob 1.0.1
+// TestUpdateNodeDailySummary_NoDoubleAggregation verifies that calling UpdateNodeDailySummary
+// multiple times with the same node_id, date, and core_count correctly increments total_hours
+// without double-counting. This tests the fix for the double aggregation issue.
+func TestUpdateNodeDailySummary_NoDoubleAggregation(t *testing.T) {
+	pool, newTx := testutils.SetupTestDB(t)
+	tx := newTx()
+	defer tx.Rollback(context.Background())
+
+	repo := NewRepository(pool)
+
+	clusterID, _ := uuid.Parse("10f5a0f9-223a-41c1-8456-9a3eb0323a99")
+	nodeName := "test-node"
+	identifier := "test-identifier"
+	nodeRole := "worker"
+
+	// Create node
+	nodeID, err := repo.UpsertNode(clusterID, nodeName, identifier, nodeRole)
+	require.NoError(t, err)
+
+	timestamp, _ := time.Parse("2006-01-02 15:04:05 +0000 MST", "2025-05-17 14:00:00 +0000 UTC")
+	coreCount := 4
+
+	// First update - should create entry with total_hours = 1
+	err = repo.UpdateNodeDailySummary(nodeID, timestamp, coreCount)
+	require.NoError(t, err)
+
+	var totalHours int
+	err = tx.QueryRow(context.Background(),
+		"SELECT total_hours FROM node_daily_summary WHERE node_id = $1 AND date = $2 AND core_count = $3",
+		nodeID, "2025-05-17", coreCount).Scan(&totalHours)
+	require.NoError(t, err)
+	assert.Equal(t, 1, totalHours, "First update should set total_hours to 1")
+
+	// Second update with same parameters - should increment to 2
+	err = repo.UpdateNodeDailySummary(nodeID, timestamp, coreCount)
+	require.NoError(t, err)
+
+	err = tx.QueryRow(context.Background(),
+		"SELECT total_hours FROM node_daily_summary WHERE node_id = $1 AND date = $2 AND core_count = $3",
+		nodeID, "2025-05-17", coreCount).Scan(&totalHours)
+	require.NoError(t, err)
+	assert.Equal(t, 2, totalHours, "Second update should increment total_hours to 2")
+
+	// Third update - should increment to 3
+	err = repo.UpdateNodeDailySummary(nodeID, timestamp, coreCount)
+	require.NoError(t, err)
+
+	err = tx.QueryRow(context.Background(),
+		"SELECT total_hours FROM node_daily_summary WHERE node_id = $1 AND date = $2 AND core_count = $3",
+		nodeID, "2025-05-17", coreCount).Scan(&totalHours)
+	require.NoError(t, err)
+	assert.Equal(t, 3, totalHours, "Third update should increment total_hours to 3")
+}
+
+// Made with Bob 1.0.1
+// TestUpdateNodeDailySummary_DifferentCoreCountsSameDay verifies that different core counts
+// on the same day create separate entries in node_daily_summary
+func TestUpdateNodeDailySummary_DifferentCoreCountsSameDay(t *testing.T) {
+	pool, newTx := testutils.SetupTestDB(t)
+	tx := newTx()
+	defer tx.Rollback(context.Background())
+
+	repo := NewRepository(pool)
+
+	clusterID, _ := uuid.Parse("10f5a0f9-223a-41c1-8456-9a3eb0323a99")
+	nodeName := "test-node"
+	identifier := "test-identifier"
+	nodeRole := "worker"
+
+	nodeID, err := repo.UpsertNode(clusterID, nodeName, identifier, nodeRole)
+	require.NoError(t, err)
+
+	timestamp, _ := time.Parse("2006-01-02 15:04:05 +0000 MST", "2025-05-17 14:00:00 +0000 UTC")
+
+	// Update with core_count = 4
+	err = repo.UpdateNodeDailySummary(nodeID, timestamp, 4)
+	require.NoError(t, err)
+
+	// Update with core_count = 8
+	err = repo.UpdateNodeDailySummary(nodeID, timestamp, 8)
+	require.NoError(t, err)
+
+	// Verify two separate entries exist
+	var count int
+	err = tx.QueryRow(context.Background(),
+		"SELECT COUNT(*) FROM node_daily_summary WHERE node_id = $1 AND date = $2",
+		nodeID, "2025-05-17").Scan(&count)
+	require.NoError(t, err)
+	assert.Equal(t, 2, count, "Should have two entries for different core counts")
+
+	// Verify each has total_hours = 1
+	var totalHours4, totalHours8 int
+	err = tx.QueryRow(context.Background(),
+		"SELECT total_hours FROM node_daily_summary WHERE node_id = $1 AND date = $2 AND core_count = $3",
+		nodeID, "2025-05-17", 4).Scan(&totalHours4)
+	require.NoError(t, err)
+	assert.Equal(t, 1, totalHours4)
+
+	err = tx.QueryRow(context.Background(),
+		"SELECT total_hours FROM node_daily_summary WHERE node_id = $1 AND date = $2 AND core_count = $3",
+		nodeID, "2025-05-17", 8).Scan(&totalHours8)
+	require.NoError(t, err)
+	assert.Equal(t, 1, totalHours8)
+}
+
 func TestUpsertPod(t *testing.T) {
 	pool, newTx := testutils.SetupTestDB(t)
 	tx := newTx()
@@ -165,6 +271,81 @@ func TestInsertPodMetric(t *testing.T) {
 	assert.Equal(t, 1, count, "Expected one row in pod_metrics")
 }
 
+// Made with Bob 1.0.1
+// TestInsertPodMetric_NoDoubleAggregation verifies that calling InsertPodMetric
+// multiple times with the same pod_id and timestamp replaces values instead of
+// aggregating them. This tests the fix for the double aggregation bug.
+func TestInsertPodMetric_NoDoubleAggregation(t *testing.T) {
+	pool, newTx := testutils.SetupTestDB(t)
+	tx := newTx()
+	defer tx.Rollback(context.Background())
+
+	repo := NewRepository(pool)
+
+	clusterID, _ := uuid.Parse("10f5a0f9-223a-41c1-8456-9a3eb0323a99")
+	nodeName := "test-node"
+	identifier := "test-identifier"
+	nodeRole := "worker"
+	podName := "test-pod"
+	namespace := "test-namespace"
+	component := "test-component"
+
+	// Create node and pod
+	nodeID, err := repo.UpsertNode(clusterID, nodeName, identifier, nodeRole)
+	require.NoError(t, err)
+
+	podID, err := repo.UpsertPod(clusterID, nodeID, podName, namespace, component)
+	require.NoError(t, err)
+
+	now := time.Now().UTC()
+	year, month := now.Year(), now.Month()
+	timestamp := time.Date(year, month, 15, 14, 0, 0, 0, time.UTC)
+
+	// First insert
+	usage1 := 100.0
+	request1 := 200.0
+	nodeCap := 14400.0
+	coreCount := 4
+
+	err = repo.InsertPodMetric(podID, timestamp, usage1, request1, nodeCap, coreCount)
+	require.NoError(t, err)
+
+	// Verify first insert
+	var storedUsage, storedRequest float64
+	err = tx.QueryRow(context.Background(),
+		"SELECT pod_usage_cpu_core_seconds, pod_request_cpu_core_seconds FROM pod_metrics WHERE pod_id = $1 AND timestamp = $2",
+		podID, timestamp).Scan(&storedUsage, &storedRequest)
+	require.NoError(t, err)
+	assert.InDelta(t, 100.0, storedUsage, 0.001, "First insert should set usage to 100.0")
+	assert.InDelta(t, 200.0, storedRequest, 0.001, "First insert should set request to 200.0")
+
+	// Second insert with same timestamp - should REPLACE, not aggregate
+	usage2 := 150.0
+	request2 := 250.0
+
+	err = repo.InsertPodMetric(podID, timestamp, usage2, request2, nodeCap, coreCount)
+	require.NoError(t, err)
+
+	// Verify second insert replaced the values (not aggregated)
+	err = tx.QueryRow(context.Background(),
+		"SELECT pod_usage_cpu_core_seconds, pod_request_cpu_core_seconds FROM pod_metrics WHERE pod_id = $1 AND timestamp = $2",
+		podID, timestamp).Scan(&storedUsage, &storedRequest)
+	require.NoError(t, err)
+
+	// With the FIX: values should be replaced (150.0, 250.0)
+	// With the BUG: values would be aggregated (100+150=250.0, 200+250=450.0)
+	assert.InDelta(t, 150.0, storedUsage, 0.001, "Second insert should REPLACE usage to 150.0, not aggregate to 250.0")
+	assert.InDelta(t, 250.0, storedRequest, 0.001, "Second insert should REPLACE request to 250.0, not aggregate to 450.0")
+
+	// Verify only one row exists
+	var count int
+	err = tx.QueryRow(context.Background(),
+		"SELECT COUNT(*) FROM pod_metrics WHERE pod_id = $1 AND timestamp = $2",
+		podID, timestamp).Scan(&count)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count, "Should have exactly one row for this pod_id and timestamp")
+}
+
 func TestUpdatePodDailySummary(t *testing.T) {
 	pool, newTx := testutils.SetupTestDB(t)
 	tx := newTx()
@@ -203,4 +384,178 @@ func TestUpdatePodDailySummary(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 1, totalHours)
 	assert.InDelta(t, 0.013888, maxCoresUsed, 0.000001)
+}
+
+// Made with Bob 1.0.1
+// TestUpdatePodDailySummary_NoDoubleAggregation verifies that calling UpdatePodDailySummary
+// multiple times correctly aggregates total_pod_effective_core_seconds and total_hours
+// without double-counting. This tests the fix for the double aggregation issue.
+func TestUpdatePodDailySummary_NoDoubleAggregation(t *testing.T) {
+	pool, newTx := testutils.SetupTestDB(t)
+	tx := newTx()
+	defer tx.Rollback(context.Background())
+
+	repo := NewRepository(pool)
+
+	clusterID, _ := uuid.Parse("10f5a0f9-223a-41c1-8456-9a3eb0323a99")
+	nodeName := "test-node"
+	identifier := "test-identifier"
+	nodeRole := "worker"
+	podName := "test-pod"
+	namespace := "test-namespace"
+	component := "test-component"
+
+	// Create node and pod
+	nodeID, err := repo.UpsertNode(clusterID, nodeName, identifier, nodeRole)
+	require.NoError(t, err)
+
+	podID, err := repo.UpsertPod(clusterID, nodeID, podName, namespace, component)
+	require.NoError(t, err)
+
+	timestamp, _ := time.Parse("2006-01-02 15:04:05 +0000 MST", "2025-05-17 14:00:00 +0000 UTC")
+	effectiveCoreSeconds := 200.0
+	coreUsage := 0.013888
+
+	// First update - should create entry with total_hours = 1, total_pod_effective_core_seconds = 200.0
+	err = repo.UpdatePodDailySummary(podID, timestamp, effectiveCoreSeconds, coreUsage)
+	require.NoError(t, err)
+
+	var totalHours int
+	var totalEffectiveCoreSeconds float64
+	var maxCoresUsed float64
+	err = tx.QueryRow(context.Background(),
+		"SELECT total_hours, total_pod_effective_core_seconds, max_cores_used FROM pod_daily_summary WHERE pod_id = $1 AND date = $2",
+		podID, "2025-05-17").Scan(&totalHours, &totalEffectiveCoreSeconds, &maxCoresUsed)
+	require.NoError(t, err)
+	assert.Equal(t, 1, totalHours, "First update should set total_hours to 1")
+	assert.InDelta(t, 200.0, totalEffectiveCoreSeconds, 0.001, "First update should set total_pod_effective_core_seconds to 200.0")
+	assert.InDelta(t, 0.013888, maxCoresUsed, 0.000001, "First update should set max_cores_used to 0.013888")
+
+	// Second update with same parameters - should increment total_hours to 2 and add to total_pod_effective_core_seconds
+	err = repo.UpdatePodDailySummary(podID, timestamp, effectiveCoreSeconds, coreUsage)
+	require.NoError(t, err)
+
+	err = tx.QueryRow(context.Background(),
+		"SELECT total_hours, total_pod_effective_core_seconds, max_cores_used FROM pod_daily_summary WHERE pod_id = $1 AND date = $2",
+		podID, "2025-05-17").Scan(&totalHours, &totalEffectiveCoreSeconds, &maxCoresUsed)
+	require.NoError(t, err)
+	assert.Equal(t, 2, totalHours, "Second update should increment total_hours to 2")
+	assert.InDelta(t, 400.0, totalEffectiveCoreSeconds, 0.001, "Second update should add to total_pod_effective_core_seconds (200 + 200 = 400)")
+	assert.InDelta(t, 0.013888, maxCoresUsed, 0.000001, "max_cores_used should remain the same")
+
+	// Third update with higher core usage - should update max_cores_used
+	higherCoreUsage := 0.025
+	err = repo.UpdatePodDailySummary(podID, timestamp, effectiveCoreSeconds, higherCoreUsage)
+	require.NoError(t, err)
+
+	err = tx.QueryRow(context.Background(),
+		"SELECT total_hours, total_pod_effective_core_seconds, max_cores_used FROM pod_daily_summary WHERE pod_id = $1 AND date = $2",
+		podID, "2025-05-17").Scan(&totalHours, &totalEffectiveCoreSeconds, &maxCoresUsed)
+	require.NoError(t, err)
+	assert.Equal(t, 3, totalHours, "Third update should increment total_hours to 3")
+	assert.InDelta(t, 600.0, totalEffectiveCoreSeconds, 0.001, "Third update should add to total_pod_effective_core_seconds (400 + 200 = 600)")
+	assert.InDelta(t, 0.025, maxCoresUsed, 0.000001, "max_cores_used should be updated to the higher value")
+}
+
+// Made with Bob 1.0.1
+// TestUpdatePodDailySummary_MaxCoresUsedTracking verifies that max_cores_used
+// correctly tracks the maximum value across multiple updates
+func TestUpdatePodDailySummary_MaxCoresUsedTracking(t *testing.T) {
+	pool, newTx := testutils.SetupTestDB(t)
+	tx := newTx()
+	defer tx.Rollback(context.Background())
+
+	repo := NewRepository(pool)
+
+	clusterID, _ := uuid.Parse("10f5a0f9-223a-41c1-8456-9a3eb0323a99")
+	nodeName := "test-node"
+	identifier := "test-identifier"
+	nodeRole := "worker"
+	podName := "test-pod"
+	namespace := "test-namespace"
+	component := "test-component"
+
+	nodeID, err := repo.UpsertNode(clusterID, nodeName, identifier, nodeRole)
+	require.NoError(t, err)
+
+	podID, err := repo.UpsertPod(clusterID, nodeID, podName, namespace, component)
+	require.NoError(t, err)
+
+	timestamp, _ := time.Parse("2006-01-02 15:04:05 +0000 MST", "2025-05-17 14:00:00 +0000 UTC")
+
+	// Update with increasing core usage values
+	coreUsageValues := []float64{0.01, 0.05, 0.03, 0.08, 0.02}
+	effectiveCoreSeconds := 200.0
+
+	for _, coreUsage := range coreUsageValues {
+		err = repo.UpdatePodDailySummary(podID, timestamp, effectiveCoreSeconds, coreUsage)
+		require.NoError(t, err)
+	}
+
+	var maxCoresUsed float64
+	err = tx.QueryRow(context.Background(),
+		"SELECT max_cores_used FROM pod_daily_summary WHERE pod_id = $1 AND date = $2",
+		podID, "2025-05-17").Scan(&maxCoresUsed)
+	require.NoError(t, err)
+	assert.InDelta(t, 0.08, maxCoresUsed, 0.000001, "max_cores_used should be the maximum value (0.08)")
+}
+
+// Made with Bob 1.0.1
+// TestUpdatePodDailySummary_DifferentDays verifies that updates on different days
+// create separate entries in pod_daily_summary
+func TestUpdatePodDailySummary_DifferentDays(t *testing.T) {
+	pool, newTx := testutils.SetupTestDB(t)
+	tx := newTx()
+	defer tx.Rollback(context.Background())
+
+	repo := NewRepository(pool)
+
+	clusterID, _ := uuid.Parse("10f5a0f9-223a-41c1-8456-9a3eb0323a99")
+	nodeName := "test-node"
+	identifier := "test-identifier"
+	nodeRole := "worker"
+	podName := "test-pod"
+	namespace := "test-namespace"
+	component := "test-component"
+
+	nodeID, err := repo.UpsertNode(clusterID, nodeName, identifier, nodeRole)
+	require.NoError(t, err)
+
+	podID, err := repo.UpsertPod(clusterID, nodeID, podName, namespace, component)
+	require.NoError(t, err)
+
+	timestamp1, _ := time.Parse("2006-01-02 15:04:05 +0000 MST", "2025-05-17 14:00:00 +0000 UTC")
+	timestamp2, _ := time.Parse("2006-01-02 15:04:05 +0000 MST", "2025-05-18 14:00:00 +0000 UTC")
+	effectiveCoreSeconds := 200.0
+	coreUsage := 0.013888
+
+	// Update for day 1
+	err = repo.UpdatePodDailySummary(podID, timestamp1, effectiveCoreSeconds, coreUsage)
+	require.NoError(t, err)
+
+	// Update for day 2
+	err = repo.UpdatePodDailySummary(podID, timestamp2, effectiveCoreSeconds, coreUsage)
+	require.NoError(t, err)
+
+	// Verify two separate entries exist
+	var count int
+	err = tx.QueryRow(context.Background(),
+		"SELECT COUNT(*) FROM pod_daily_summary WHERE pod_id = $1",
+		podID).Scan(&count)
+	require.NoError(t, err)
+	assert.Equal(t, 2, count, "Should have two entries for different days")
+
+	// Verify each has total_hours = 1
+	var totalHours1, totalHours2 int
+	err = tx.QueryRow(context.Background(),
+		"SELECT total_hours FROM pod_daily_summary WHERE pod_id = $1 AND date = $2",
+		podID, "2025-05-17").Scan(&totalHours1)
+	require.NoError(t, err)
+	assert.Equal(t, 1, totalHours1)
+
+	err = tx.QueryRow(context.Background(),
+		"SELECT total_hours FROM pod_daily_summary WHERE pod_id = $1 AND date = $2",
+		podID, "2025-05-18").Scan(&totalHours2)
+	require.NoError(t, err)
+	assert.Equal(t, 1, totalHours2)
 }

--- a/internal/db/testutils/setup.go
+++ b/internal/db/testutils/setup.go
@@ -2,7 +2,6 @@ package testutils
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -16,10 +15,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Global mutex to prevent concurrent schema setup across all tests
+var setupMutex sync.Mutex
+
 // SetupTestDB creates a database connection pool and sets up the schema for testing.
 // It returns the pool and a function to start a new transaction for each test case.
 // The pool is closed only after all tests in the suite complete.
 func SetupTestDB(t *testing.T) (*pgxpool.Pool, func() pgx.Tx) {
+	// Lock to prevent concurrent schema setup
+	setupMutex.Lock()
+	defer setupMutex.Unlock()
+
 	dbURL := "postgres://costmetrics:costmetrics@localhost:5432/costmetrics?sslmode=disable"
 	config, err := pgxpool.ParseConfig(dbURL)
 	require.NoError(t, err)
@@ -41,83 +47,70 @@ func SetupTestDB(t *testing.T) (*pgxpool.Pool, func() pgx.Tx) {
 		}
 	})
 
-	// Drop and recreate schema in a transaction
-	tx, err := pool.Begin(context.Background())
-	require.NoError(t, err)
+	// Check if schema exists by trying to query a table
+	var schemaExists bool
+	err = pool.QueryRow(context.Background(), "SELECT EXISTS (SELECT FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'clusters')").Scan(&schemaExists)
 
-	_, err = tx.Exec(context.Background(), `
-		DROP TABLE IF EXISTS pod_daily_summary, pod_metrics, pods, 
-		node_daily_summary, node_metrics, nodes, clusters CASCADE
-	`)
-	require.NoError(t, err)
+	if err != nil || !schemaExists {
+		// Drop and recreate schema completely to avoid type conflicts
+		tx, err := pool.Begin(context.Background())
+		require.NoError(t, err)
 
-	_, currentFile, _, ok := runtime.Caller(0)
-	if !ok {
-		panic("Could not get caller information")
+		_, err = tx.Exec(context.Background(), `
+			DROP SCHEMA IF EXISTS public CASCADE;
+			CREATE SCHEMA public;
+			GRANT ALL ON SCHEMA public TO costmetrics;
+			GRANT ALL ON SCHEMA public TO public;
+		`)
+		require.NoError(t, err)
+
+		_, currentFile, _, ok := runtime.Caller(0)
+		if !ok {
+			panic("Could not get caller information")
+		}
+		currentDir := filepath.Dir(currentFile)
+
+		schemaPath := filepath.Join(currentDir, "..", "migrations", "0001_init.up.sql")
+		schema, err := os.ReadFile(schemaPath)
+		require.NoError(t, err)
+		_, err = tx.Exec(context.Background(), string(schema))
+		require.NoError(t, err)
+
+		// May 2025 partition (all tests use dates in this month)
+		_, err = tx.Exec(context.Background(), `
+			CREATE TABLE IF NOT EXISTS node_metrics_202505 PARTITION OF node_metrics
+			FOR VALUES FROM ('2025-05-01') TO ('2025-06-01');
+			CREATE TABLE IF NOT EXISTS pod_metrics_202505 PARTITION OF pod_metrics
+			FOR VALUES FROM ('2025-05-01') TO ('2025-06-01')
+		`)
+		require.NoError(t, err)
+
+		// Commit initial setup
+		err = tx.Commit(context.Background())
+		require.NoError(t, err)
+	} else {
+		// Schema exists, clean up data from previous tests
+		_, err = pool.Exec(context.Background(), `
+			TRUNCATE TABLE pod_metrics CASCADE;
+			TRUNCATE TABLE node_metrics CASCADE;
+			TRUNCATE TABLE pod_daily_summary CASCADE;
+			TRUNCATE TABLE node_daily_summary CASCADE;
+			TRUNCATE TABLE pods CASCADE;
+			TRUNCATE TABLE nodes CASCADE;
+			TRUNCATE TABLE clusters CASCADE;
+		`)
+		require.NoError(t, err)
+		// Small delay to ensure cleanup completes
+		time.Sleep(50 * time.Millisecond)
 	}
-	currentDir := filepath.Dir(currentFile)
 
-	schemaPath := filepath.Join(currentDir, "..", "migrations", "0001_init.up.sql")
-	schema, err := os.ReadFile(schemaPath)
-	require.NoError(t, err)
-	_, err = tx.Exec(context.Background(), string(schema))
-	require.NoError(t, err)
-
-	// Insert test data
+	// Insert test cluster for each test
 	clusterID, _ := uuid.Parse("10f5a0f9-223a-41c1-8456-9a3eb0323a99")
-	_, err = tx.Exec(context.Background(), `
+	_, err = pool.Exec(context.Background(), `
 		INSERT INTO clusters (id, name) VALUES ($1, 'test-cluster')
+		ON CONFLICT (id) DO NOTHING
 	`, clusterID)
 	require.NoError(t, err)
-
-	// nodeID, _ := uuid.Parse("fba4e7cd-4ee2-4f24-880d-082eb2b41128")
-	// _, err = tx.Exec(context.Background(), `
-	// 	INSERT INTO nodes (id, cluster_id, name, identifier, type)
-	// 	VALUES ($1, $2, 'ip-10-0-1-63.ec2.internal', 'i-09ad6102842b9a786', 'worker')
-	// `, nodeID, clusterID)
-	// require.NoError(t, err)
-	now := time.Now().UTC()
-	year, month := now.Year(), int(now.Month())
-
-	start := time.Date(year, time.Month(month), 1, 0, 0, 0, 0, time.UTC)
-	end := start.AddDate(0, 1, 0) // First day of next month
-
-	partitionNameNode := fmt.Sprintf("node_metrics_%d%02d", year, int(month))
-	partitionNamePod := fmt.Sprintf("pod_metrics_%d%02d", year, int(month))
-
-	sql := fmt.Sprintf(`
-	CREATE TABLE IF NOT EXISTS %s PARTITION OF node_metrics
-		FOR VALUES FROM ('%s') TO ('%s');
-	CREATE TABLE IF NOT EXISTS %s PARTITION OF pod_metrics
-		FOR VALUES FROM ('%s') TO ('%s');`,
-		partitionNameNode, start.Format("2006-01-02"), end.Format("2006-01-02"),
-		partitionNamePod, start.Format("2006-01-02"), end.Format("2006-01-02"))
-
-	_, err = tx.Exec(context.Background(), sql)
-	require.NoError(t, err)
-
-	// Commit initial setup
-	err = tx.Commit(context.Background())
-	require.NoError(t, err)
-
-	// Truncate tables before each test
-	t.Cleanup(func() {
-		tx, err := pool.Begin(context.Background())
-		if err != nil {
-			t.Fatalf("Failed to begin cleanup transaction: %v", err)
-		}
-		_, err = tx.Exec(context.Background(), `
-			TRUNCATE TABLE pod_daily_summary, pod_metrics, pods, 
-			node_daily_summary, node_metrics, nodes, clusters CASCADE
-		`)
-		if err != nil {
-			t.Fatalf("Failed to truncate tables: %v", err)
-		}
-		err = tx.Commit(context.Background())
-		if err != nil {
-			t.Fatalf("Failed to commit cleanup transaction: %v", err)
-		}
-	})
 
 	// Return a function to start a new transaction
 	newTx := func() pgx.Tx {

--- a/internal/processor/csv_processor.go
+++ b/internal/processor/csv_processor.go
@@ -255,13 +255,23 @@ func ProcessCSV(ctx context.Context, repo *db.Repository, reader *csv.Reader, cl
 
 	// Update node daily summaries
 	for nodeID, dates := range nodeMetrics {
-		for _, hours := range dates {
+		for dateStr, hours := range dates {
+			// Count unique hours for this node on this date
+			hourCount := len(hours)
+
+			// Find the max core count across all hours for this date
+			maxCoreCount := 0
 			for _, metric := range hours {
-				err := repo.UpdateNodeDailySummary(nodeID, metric.timestamp, metric.maxCoreCount)
-				if err != nil {
-					log.Printf("Failed to update node_daily_summary for node %s at %s with core_count %d: %v", nodeID, metric.timestamp, metric.maxCoreCount, err)
-					continue
+				if metric.maxCoreCount > maxCoreCount {
+					maxCoreCount = metric.maxCoreCount
 				}
+			}
+
+			// Update summary with the count of unique hours
+			err := repo.UpdateNodeDailySummary(nodeID, dateStr, maxCoreCount, hourCount)
+			if err != nil {
+				log.Printf("Failed to update node_daily_summary for node %s on %s with core_count %d: %v", nodeID, dateStr, maxCoreCount, err)
+				continue
 			}
 		}
 	}
@@ -269,13 +279,6 @@ func ProcessCSV(ctx context.Context, repo *db.Repository, reader *csv.Reader, cl
 	// Update pod daily summaries after processing all records
 	for podID, dates := range podMetrics {
 		for dateStr, hours := range dates {
-			// Parse the date string back to time.Time
-			date, err := time.Parse("2006-01-02", dateStr)
-			if err != nil {
-				log.Printf("Failed to parse date %s: %v", dateStr, err)
-				continue
-			}
-
 			// Count unique hours for this pod on this date
 			hourCount := len(hours)
 
@@ -290,17 +293,17 @@ func ProcessCSV(ctx context.Context, repo *db.Repository, reader *csv.Reader, cl
 				}
 				totalEffectiveCoreSeconds += podEffectiveCoreSeconds
 
-				podEffectiveCoreUsage := 0.0
-				if metric.nodeCap > 0 {
-					podEffectiveCoreUsage = podEffectiveCoreSeconds / metric.nodeCap
-				}
-				if podEffectiveCoreUsage > maxCoreUsage {
-					maxCoreUsage = podEffectiveCoreUsage
+				// Convert core-seconds to average cores for this hour
+				// pod_usage_cpu_core_seconds is the total CPU consumed in the hour
+				// Dividing by 3600 seconds gives average cores during that hour
+				podCoresUsed := podEffectiveCoreSeconds / 3600.0
+				if podCoresUsed > maxCoreUsage {
+					maxCoreUsage = podCoresUsed
 				}
 			}
 
 			// Update summary with the count of unique hours
-			err = repo.UpdatePodDailySummaryWithHours(podID, date, maxCoreUsage, totalEffectiveCoreSeconds, hourCount)
+			err := repo.UpdatePodDailySummary(podID, dateStr, maxCoreUsage, totalEffectiveCoreSeconds, hourCount)
 			if err != nil {
 				log.Printf("Failed to update pod_daily_summary for pod %s on %s: %v", podID, dateStr, err)
 				continue

--- a/internal/processor/csv_processor.go
+++ b/internal/processor/csv_processor.go
@@ -39,9 +39,12 @@ func ProcessCSV(ctx context.Context, repo *db.Repository, reader *csv.Reader, cl
 		return fmt.Errorf("failed to read CSV records: %w", err)
 	}
 
-	// Check if CSV is empty
-	if len(records) < 1 {
-		return fmt.Errorf("empty CSV file")
+	// Check if CSV is empty or has no data rows
+	if len(records) == 0 {
+		return fmt.Errorf("empty CSV file: no records found")
+	}
+	if len(records) < 2 {
+		return fmt.Errorf("CSV file has no data rows: only headers present")
 	}
 
 	// Map header indices
@@ -85,7 +88,8 @@ func ProcessCSV(ctx context.Context, repo *db.Repository, reader *csv.Reader, cl
 		nodeCap   float64
 		coreCount int
 	}
-	podMetrics := make(map[uuid.UUID]map[time.Time]podMetric)
+	// Track pod metrics by hour (podID -> date -> hour -> metric)
+	podMetrics := make(map[uuid.UUID]map[string]map[time.Time]podMetric)
 
 	// Process each record
 	for i, record := range records[1:] {
@@ -231,24 +235,21 @@ func ProcessCSV(ctx context.Context, repo *db.Repository, reader *csv.Reader, cl
 			continue
 		}
 
-		// Track pod metrics for daily summary
+		// Track pod metrics for daily summary by hour
+		podDateStr := intervalStart.Truncate(24 * time.Hour).Format("2006-01-02")
+		podHour := intervalStart.Truncate(time.Hour)
 		if _, ok := podMetrics[podID]; !ok {
-			podMetrics[podID] = make(map[time.Time]podMetric)
+			podMetrics[podID] = make(map[string]map[time.Time]podMetric)
 		}
-		if metric, ok := podMetrics[podID][intervalStart]; ok {
-			// Aggregate usage and request, keep latest node capacity
-			metric.usage += podUsage
-			metric.request += podRequest
-			metric.nodeCap = nodeCapacityCPUCoreSeconds
-			metric.coreCount = int(capacityCPU)
-			podMetrics[podID][intervalStart] = metric
-		} else {
-			podMetrics[podID][intervalStart] = podMetric{
-				usage:     podUsage,
-				request:   podRequest,
-				nodeCap:   nodeCapacityCPUCoreSeconds,
-				coreCount: int(capacityCPU),
-			}
+		if _, ok := podMetrics[podID][podDateStr]; !ok {
+			podMetrics[podID][podDateStr] = make(map[time.Time]podMetric)
+		}
+		// Store the latest values for this hour (overwrite if multiple records in same hour)
+		podMetrics[podID][podDateStr][podHour] = podMetric{
+			usage:     podUsage,
+			request:   podRequest,
+			nodeCap:   nodeCapacityCPUCoreSeconds,
+			coreCount: int(capacityCPU),
 		}
 	}
 
@@ -266,19 +267,42 @@ func ProcessCSV(ctx context.Context, repo *db.Repository, reader *csv.Reader, cl
 	}
 
 	// Update pod daily summaries after processing all records
-	for podID, timestamps := range podMetrics {
-		for ts, metric := range timestamps {
-			podEffectiveCoreSeconds := metric.usage
-			if metric.request > metric.usage {
-				podEffectiveCoreSeconds = metric.request
-			}
-			podEffectiveCoreUsage := 0.0
-			if metric.nodeCap > 0 {
-				podEffectiveCoreUsage = podEffectiveCoreSeconds / metric.nodeCap
-			}
-			err := repo.UpdatePodDailySummary(podID, ts, podEffectiveCoreSeconds, podEffectiveCoreUsage)
+	for podID, dates := range podMetrics {
+		for dateStr, hours := range dates {
+			// Parse the date string back to time.Time
+			date, err := time.Parse("2006-01-02", dateStr)
 			if err != nil {
-				log.Printf("Failed to update pod_daily_summary for pod %s at %s: %v", podID, ts, err)
+				log.Printf("Failed to parse date %s: %v", dateStr, err)
+				continue
+			}
+
+			// Count unique hours for this pod on this date
+			hourCount := len(hours)
+
+			// Aggregate metrics across all hours for this date
+			var totalEffectiveCoreSeconds float64
+			var maxCoreUsage float64
+
+			for _, metric := range hours {
+				podEffectiveCoreSeconds := metric.usage
+				if metric.request > metric.usage {
+					podEffectiveCoreSeconds = metric.request
+				}
+				totalEffectiveCoreSeconds += podEffectiveCoreSeconds
+
+				podEffectiveCoreUsage := 0.0
+				if metric.nodeCap > 0 {
+					podEffectiveCoreUsage = podEffectiveCoreSeconds / metric.nodeCap
+				}
+				if podEffectiveCoreUsage > maxCoreUsage {
+					maxCoreUsage = podEffectiveCoreUsage
+				}
+			}
+
+			// Update summary with the count of unique hours
+			err = repo.UpdatePodDailySummaryWithHours(podID, date, maxCoreUsage, totalEffectiveCoreSeconds, hourCount)
+			if err != nil {
+				log.Printf("Failed to update pod_daily_summary for pod %s on %s: %v", podID, dateStr, err)
 				continue
 			}
 		}

--- a/internal/processor/csv_processor_test.go
+++ b/internal/processor/csv_processor_test.go
@@ -3,6 +3,7 @@ package processor
 import (
 	"context"
 	"encoding/csv"
+	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -263,4 +264,189 @@ func TestProcessCSVMultipleDaysHours(t *testing.T) {
 		"pod-1", "2025-05-18").Scan(&day2Hours)
 	require.NoError(t, err)
 	assert.Equal(t, 3, day2Hours, "Day 2 should have 3 unique hours (10:00, 11:00, 12:00)")
+}
+
+// Made with Bob 1.0.1
+// TestProcessCSVNodeTotalHoursCount verifies that node total_hours counts unique hours, not total records
+func TestProcessCSVNodeTotalHoursCount(t *testing.T) {
+	pool := testutils.SetupTestDB(t)
+	repo := db.NewRepository(pool)
+	ctx := context.Background()
+
+	os.Setenv("POD_LABEL_KEYS", "label_rht_comp")
+	defer os.Unsetenv("POD_LABEL_KEYS")
+
+	clusterID := "10f5a0f9-223a-41c1-8456-9a3eb0323a99"
+	clusterUUID, _ := uuid.Parse(clusterID)
+
+	// Setup cluster
+	err := repo.UpsertCluster(clusterUUID, "test-cluster")
+	require.NoError(t, err)
+
+	// Create CSV with multiple records in the same hours for nodes
+	// Simulates the scenario: 1 node, 3 unique hours, but 30 total records
+	// Hour 14:00 - 10 records
+	// Hour 15:00 - 10 records
+	// Hour 16:00 - 10 records
+	// Total: 30 records, but only 3 unique hours
+	csvBuilder := strings.Builder{}
+	csvBuilder.WriteString("report_period_start,report_period_end,interval_start,interval_end,node,namespace,pod,pod_usage_cpu_core_seconds,pod_request_cpu_core_seconds,pod_limit_cpu_core_seconds,pod_usage_memory_byte_seconds,pod_request_memory_byte_seconds,pod_limit_memory_byte_seconds,node_capacity_cpu_cores,node_capacity_cpu_core_seconds,node_capacity_memory_bytes,node_capacity_memory_byte_seconds,node_role,resource_id,pod_labels\n")
+
+	// Generate 10 records for hour 14:00
+	for i := 0; i < 10; i++ {
+		csvBuilder.WriteString("2025-05-17 00:00:00 +0000 UTC,2025-05-17 23:59:59 +0000 UTC,2025-05-17 14:00:00 +0000 UTC,2025-05-17 15:00:00 +0000 UTC,test-node-1,test,test-pod,100,200,300,1000,2000,3000,8,14400,17179869184,61729433600,worker,node-id-123,app:web|label_rht_comp:TEST\n")
+	}
+
+	// Generate 10 records for hour 15:00
+	for i := 0; i < 10; i++ {
+		csvBuilder.WriteString("2025-05-17 00:00:00 +0000 UTC,2025-05-17 23:59:59 +0000 UTC,2025-05-17 15:00:00 +0000 UTC,2025-05-17 16:00:00 +0000 UTC,test-node-1,test,test-pod,150,250,350,1500,2500,3500,8,14400,17179869184,61729433600,worker,node-id-123,app:web|label_rht_comp:TEST\n")
+	}
+
+	// Generate 10 records for hour 16:00
+	for i := 0; i < 10; i++ {
+		csvBuilder.WriteString("2025-05-17 00:00:00 +0000 UTC,2025-05-17 23:59:59 +0000 UTC,2025-05-17 16:00:00 +0000 UTC,2025-05-17 17:00:00 +0000 UTC,test-node-1,test,test-pod,200,300,400,2000,3000,4000,8,14400,17179869184,61729433600,worker,node-id-123,app:web|label_rht_comp:TEST\n")
+	}
+
+	reader := csv.NewReader(strings.NewReader(csvBuilder.String()))
+	err = ProcessCSV(ctx, repo, reader, clusterID)
+	assert.NoError(t, err)
+
+	// Query node_daily_summary to check total_hours
+	var totalHours int
+	err = pool.QueryRow(context.Background(),
+		`SELECT total_hours 
+		 FROM node_daily_summary nds
+		 JOIN nodes n ON nds.node_id = n.id
+		 WHERE n.name = $1 AND nds.date = $2 AND nds.core_count = $3`,
+		"test-node-1", "2025-05-17", 8).Scan(&totalHours)
+
+	require.NoError(t, err, "Should find node_daily_summary record")
+
+	// The fix: total_hours should be 3 (unique hours: 14:00, 15:00, 16:00)
+	// NOT 30 (total number of records)
+	assert.Equal(t, 3, totalHours, "total_hours should count unique hours (3), not total records (30)")
+}
+
+// Made with Bob 1.0.1
+// TestProcessCSVNodeMultipleDaysHours verifies node total_hours across multiple days
+func TestProcessCSVNodeMultipleDaysHours(t *testing.T) {
+	pool := testutils.SetupTestDB(t)
+	repo := db.NewRepository(pool)
+	ctx := context.Background()
+
+	os.Setenv("POD_LABEL_KEYS", "label_rht_comp")
+	defer os.Unsetenv("POD_LABEL_KEYS")
+
+	clusterID := "10f5a0f9-223a-41c1-8456-9a3eb0323a99"
+	clusterUUID, _ := uuid.Parse(clusterID)
+
+	err := repo.UpsertCluster(clusterUUID, "test-cluster")
+	require.NoError(t, err)
+
+	// CSV with node data across 2 days
+	// Day 1 (May 17): 2 unique hours (14:00, 15:00) with 5 records each
+	// Day 2 (May 18): 4 unique hours (10:00, 11:00, 12:00, 13:00) with 3 records each
+	csvBuilder := strings.Builder{}
+	csvBuilder.WriteString("report_period_start,report_period_end,interval_start,interval_end,node,namespace,pod,pod_usage_cpu_core_seconds,pod_request_cpu_core_seconds,pod_limit_cpu_core_seconds,pod_usage_memory_byte_seconds,pod_request_memory_byte_seconds,pod_limit_memory_byte_seconds,node_capacity_cpu_cores,node_capacity_cpu_core_seconds,node_capacity_memory_bytes,node_capacity_memory_byte_seconds,node_role,resource_id,pod_labels\n")
+
+	// Day 1: 5 records at 14:00
+	for i := 0; i < 5; i++ {
+		csvBuilder.WriteString("2025-05-17 00:00:00 +0000 UTC,2025-05-17 23:59:59 +0000 UTC,2025-05-17 14:00:00 +0000 UTC,2025-05-17 15:00:00 +0000 UTC,node-multi,test,pod-1,100,200,300,1000,2000,3000,4,14400,17179869184,61729433600,worker,node-456,label_rht_comp:TEST\n")
+	}
+
+	// Day 1: 5 records at 15:00
+	for i := 0; i < 5; i++ {
+		csvBuilder.WriteString("2025-05-17 00:00:00 +0000 UTC,2025-05-17 23:59:59 +0000 UTC,2025-05-17 15:00:00 +0000 UTC,2025-05-17 16:00:00 +0000 UTC,node-multi,test,pod-1,150,250,350,1500,2500,3500,4,14400,17179869184,61729433600,worker,node-456,label_rht_comp:TEST\n")
+	}
+
+	// Day 2: 3 records each for 4 different hours
+	for hour := 10; hour <= 13; hour++ {
+		for i := 0; i < 3; i++ {
+			csvBuilder.WriteString(fmt.Sprintf("2025-05-18 00:00:00 +0000 UTC,2025-05-18 23:59:59 +0000 UTC,2025-05-18 %02d:00:00 +0000 UTC,2025-05-18 %02d:00:00 +0000 UTC,node-multi,test,pod-1,200,300,400,2000,3000,4000,4,14400,17179869184,61729433600,worker,node-456,label_rht_comp:TEST\n", hour, hour+1))
+		}
+	}
+
+	reader := csv.NewReader(strings.NewReader(csvBuilder.String()))
+	err = ProcessCSV(ctx, repo, reader, clusterID)
+	assert.NoError(t, err)
+
+	// Check Day 1 (May 17) - should have 2 unique hours
+	var day1Hours int
+	err = pool.QueryRow(context.Background(),
+		`SELECT total_hours FROM node_daily_summary nds
+		 JOIN nodes n ON nds.node_id = n.id
+		 WHERE n.name = $1 AND nds.date = $2 AND nds.core_count = $3`,
+		"node-multi", "2025-05-17", 4).Scan(&day1Hours)
+	require.NoError(t, err)
+	assert.Equal(t, 2, day1Hours, "Day 1 should have 2 unique hours (14:00, 15:00)")
+
+	// Check Day 2 (May 18) - should have 4 unique hours
+	var day2Hours int
+	err = pool.QueryRow(context.Background(),
+		`SELECT total_hours FROM node_daily_summary nds
+		 JOIN nodes n ON nds.node_id = n.id
+		 WHERE n.name = $1 AND nds.date = $2 AND nds.core_count = $3`,
+		"node-multi", "2025-05-18", 4).Scan(&day2Hours)
+	require.NoError(t, err)
+	assert.Equal(t, 4, day2Hours, "Day 2 should have 4 unique hours (10:00, 11:00, 12:00, 13:00)")
+}
+
+// Made with Bob 1.0.1
+// TestProcessCSVMaxCoresUsedCalculation verifies that max_cores_used is calculated
+// correctly by dividing core-seconds by 3600 (not by node capacity)
+func TestProcessCSVMaxCoresUsedCalculation(t *testing.T) {
+	pool := testutils.SetupTestDB(t)
+	repo := db.NewRepository(pool)
+	ctx := context.Background()
+
+	os.Setenv("POD_LABEL_KEYS", "label_rht_comp")
+	defer os.Unsetenv("POD_LABEL_KEYS")
+
+	clusterID := "10f5a0f9-223a-41c1-8456-9a3eb0323a99"
+	clusterUUID, _ := uuid.Parse(clusterID)
+	podName := "eap74-helloworld-5575bdb44c-v6tgf"
+	namespace := "eap74"
+
+	// Setup cluster
+	err := repo.UpsertCluster(clusterUUID, "test-cluster")
+	require.NoError(t, err)
+
+	// CSV with realistic data from the logs:
+	// pod_usage_cpu_core_seconds: 74.406755
+	// node_capacity_cpu_core_seconds: 43200
+	// Expected max_cores_used: 74.406755 / 3600 = 0.0207 cores (not 74.406755 / 43200 = 0.00172)
+	csvData := `report_period_start,report_period_end,interval_start,interval_end,node,namespace,pod,pod_usage_cpu_core_seconds,pod_request_cpu_core_seconds,pod_limit_cpu_core_seconds,pod_usage_memory_byte_seconds,pod_request_memory_byte_seconds,pod_limit_memory_byte_seconds,node_capacity_cpu_cores,node_capacity_cpu_core_seconds,node_capacity_memory_bytes,node_capacity_memory_byte_seconds,node_role,resource_id,pod_labels
+2025-05-20 00:00:00 +0000 UTC,2025-05-20 23:59:59 +0000 UTC,2025-05-20 03:00:00 +0000 UTC,2025-05-20 03:59:59 +0000 UTC,worker-node,eap74,eap74-helloworld-5575bdb44c-v6tgf,74.406755,0,0,2556643246080,0,0,12,43200,53446742016,192408271257600,worker,i-test,label_rht_comp:EAP
+2025-05-20 00:00:00 +0000 UTC,2025-05-20 23:59:59 +0000 UTC,2025-05-20 04:00:00 +0000 UTC,2025-05-20 04:59:59 +0000 UTC,worker-node,eap74,eap74-helloworld-5575bdb44c-v6tgf,90.0,0,0,2658516664320,0,0,12,43200,53446742016,192408271257600,worker,i-test,label_rht_comp:EAP`
+
+	reader := csv.NewReader(strings.NewReader(csvData))
+	err = ProcessCSV(ctx, repo, reader, clusterID)
+	assert.NoError(t, err)
+
+	// Get pod ID
+	var podID string
+	err = pool.QueryRow(context.Background(), "SELECT id FROM pods WHERE name = $1 AND namespace = $2 AND cluster_id = $3", podName, namespace, clusterID).Scan(&podID)
+	require.NoError(t, err)
+	podUUID, _ := uuid.Parse(podID)
+
+	// Check pod_daily_summary
+	var maxCoresUsed float64
+	var totalEffectiveCoreSeconds float64
+	err = pool.QueryRow(context.Background(),
+		"SELECT max_cores_used, total_pod_effective_core_seconds FROM pod_daily_summary WHERE pod_id = $1 AND date = $2",
+		podUUID, "2025-05-20").Scan(&maxCoresUsed, &totalEffectiveCoreSeconds)
+	require.NoError(t, err)
+
+	// Hour 03:00: 74.406755 / 3600 = 0.02067 cores
+	// Hour 04:00: 90.0 / 3600 = 0.025 cores
+	// Max should be 0.025 cores (not 0.00172 which would be 74.406755 / 43200)
+	expectedMaxCores := 90.0 / 3600.0
+	assert.InDelta(t, expectedMaxCores, maxCoresUsed, 0.0001,
+		fmt.Sprintf("max_cores_used should be 90.0/3600 = %.4f cores (not 90.0/43200 = %.6f)",
+			expectedMaxCores, 90.0/43200.0))
+
+	// Total effective core seconds should sum both hours
+	expectedTotal := 74.406755 + 90.0
+	assert.InDelta(t, expectedTotal, totalEffectiveCoreSeconds, 0.001,
+		"total_pod_effective_core_seconds should sum both hours")
 }

--- a/internal/processor/csv_processor_test.go
+++ b/internal/processor/csv_processor_test.go
@@ -9,62 +9,88 @@ import (
 
 	"github.com/aptmac/cost-metrics-aggregator/internal/db"
 	"github.com/aptmac/cost-metrics-aggregator/internal/processor/testutils"
+	"github.com/google/uuid"
 
-	// "github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
-	// "github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/require"
 )
 
-// func TestProcessCSV(t *testing.T) {
-// 	pool := testutils.SetupTestDB(t)
-// 	repo := db.NewRepository(pool)
-// 	ctx := context.Background()
+// AI-ASSISTED: Bob 1.0.1
+func TestProcessCSV(t *testing.T) {
+	pool := testutils.SetupTestDB(t)
+	repo := db.NewRepository(pool)
+	ctx := context.Background()
 
-// 	os.Setenv("POD_LABEL_KEYS", "label_rht_comp")
-// 	defer os.Unsetenv("POD_LABEL_KEYS")
+	os.Setenv("POD_LABEL_KEYS", "label_rht_comp")
+	defer os.Unsetenv("POD_LABEL_KEYS")
 
-// 	clusterID := "10f5a0f9-223a-41c1-8456-9a3eb0323a99"
-// 	clusterUUID, _ := uuid.Parse(clusterID)
-// 	nodeName := "ip-10-0-1-63.ec2.internal"
-// 	// identifier := "i-09ad6102842b9a786"
-// 	// nodeRole := "worker"
-// 	// podName := "zip-1"
-// 	// namespace := "test"
-// 	// component := "EAP"
+	clusterID := "10f5a0f9-223a-41c1-8456-9a3eb0323a99"
+	clusterUUID, _ := uuid.Parse(clusterID)
+	nodeName := "ip-10-0-1-63.ec2.internal"
+	podName := "zip-1"
+	namespace := "test"
 
-// 	// Setup cluster
-// 	err := repo.UpsertCluster(clusterUUID, "test-cluster")
-// 	require.NoError(t, err)
+	// Setup cluster
+	err := repo.UpsertCluster(clusterUUID, "test-cluster")
+	require.NoError(t, err)
 
-// 	csvData := `report_period_start,report_period_end,interval_start,interval_end,node,namespace,pod,pod_usage_cpu_core_seconds,pod_request_cpu_core_seconds,pod_limit_cpu_core_seconds,pod_usage_memory_byte_seconds,pod_request_memory_byte_seconds,pod_limit_memory_byte_seconds,node_capacity_cpu_cores,node_capacity_cpu_core_seconds,node_capacity_memory_bytes,node_capacity_memory_byte_seconds,node_role,resource_id,pod_labels
-// 2025-05-17 00:00:00 +0000 UTC,2025-05-17 23:59:59 +0000 UTC,2025-05-17 14:00:00 +0000 UTC,2025-05-17 15:00:00 +0000 UTC,ip-10-0-1-63.ec2.internal,test,zip-1,150,250,350,1500,2500,3500,4,14400,17179869184,61729433600,worker,i-09ad6102842b9a786,app:web|label_rht_comp:EAP
-// 2025-05-17 00:00:00 +0000 UTC,2025-05-17 23:59:59 +0000 UTC,2025-05-17 15:00:00 +0000 UTC,2025-05-17 16:00:00 +0000 UTC,ip-10-0-1-63.ec2.internal,test,zip-1,200,300,400,2000,3000,4000,4,14400,17179869184,61729433600,worker,i-09ad6102842b9a786,app:web|label_rht_comp:EAP`
+	// CSV with 2 records at different hours (14:00 and 15:00)
+	csvData := `report_period_start,report_period_end,interval_start,interval_end,node,namespace,pod,pod_usage_cpu_core_seconds,pod_request_cpu_core_seconds,pod_limit_cpu_core_seconds,pod_usage_memory_byte_seconds,pod_request_memory_byte_seconds,pod_limit_memory_byte_seconds,node_capacity_cpu_cores,node_capacity_cpu_core_seconds,node_capacity_memory_bytes,node_capacity_memory_byte_seconds,node_role,resource_id,pod_labels
+2025-05-17 00:00:00 +0000 UTC,2025-05-17 23:59:59 +0000 UTC,2025-05-17 14:00:00 +0000 UTC,2025-05-17 15:00:00 +0000 UTC,ip-10-0-1-63.ec2.internal,test,zip-1,150,250,350,1500,2500,3500,4,14400,17179869184,61729433600,worker,i-09ad6102842b9a786,app:web|label_rht_comp:EAP
+2025-05-17 00:00:00 +0000 UTC,2025-05-17 23:59:59 +0000 UTC,2025-05-17 15:00:00 +0000 UTC,2025-05-17 16:00:00 +0000 UTC,ip-10-0-1-63.ec2.internal,test,zip-1,200,300,400,2000,3000,4000,4,14400,17179869184,61729433600,worker,i-09ad6102842b9a786,app:web|label_rht_comp:EAP`
 
-// 	reader := csv.NewReader(strings.NewReader(csvData))
-// 	err = ProcessCSV(ctx, repo, reader, clusterID)
-// 	assert.NoError(t, err)
+	reader := csv.NewReader(strings.NewReader(csvData))
+	err = ProcessCSV(ctx, repo, reader, clusterID)
+	assert.NoError(t, err)
 
-// 	var nodeID string
-// 	err = pool.QueryRow(context.Background(), "SELECT id FROM nodes WHERE name = $1 AND cluster_id = $2 ", nodeName, clusterID).Scan(&nodeID)
-// 	nodeUUID, _ := uuid.Parse(nodeID)
+	// Get node ID
+	var nodeID string
+	err = pool.QueryRow(context.Background(), "SELECT id FROM nodes WHERE name = $1 AND cluster_id = $2", nodeName, clusterID).Scan(&nodeID)
+	require.NoError(t, err)
+	nodeUUID, _ := uuid.Parse(nodeID)
 
-// 	// Check node_daily_summary
-// 	var totalHours int
-// 	err = pool.QueryRow(context.Background(), "SELECT total_hours FROM node_daily_summary WHERE node_id = $1 AND date = $2 AND core_count = $3", nodeUUID, "2025-05-17", 4).Scan(&totalHours)
-// 	assert.NoError(t, err)
-// 	assert.Equal(t, 2, totalHours, "node_daily_summary should have 2 hours (14:00, 15:00)")
+	// Check node_daily_summary - should have 2 unique hours
+	var totalHours int
+	err = pool.QueryRow(context.Background(), "SELECT total_hours FROM node_daily_summary WHERE node_id = $1 AND date = $2 AND core_count = $3", nodeUUID, "2025-05-17", 4).Scan(&totalHours)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, totalHours, "node_daily_summary should have 2 hours (14:00, 15:00)")
 
-// 	// // Check pod_metrics (aggregate usage for 14:00)
-// 	// var podUsage float64
-// 	// err = pool.QueryRow(context.Background(), "SELECT pod_usage_cpu_core_seconds FROM pod_metrics WHERE pod_id = $1 AND timestamp = $2", podID, "2025-05-17 14:00:00+00").Scan(&podUsage)
-// 	// assert.NoError(t, err)
-// 	// assert.Equal(t, 250.0, podUsage, "pod_metrics should sum usage for 14:00 (100+150)")
+	// Get pod ID
+	var podID string
+	err = pool.QueryRow(context.Background(), "SELECT id FROM pods WHERE name = $1 AND namespace = $2 AND cluster_id = $3", podName, namespace, clusterID).Scan(&podID)
+	require.NoError(t, err)
+	podUUID, _ := uuid.Parse(podID)
 
-// 	// // Check pod_metrics for 15:00
-// 	// err = pool.QueryRow(context.Background(), "SELECT pod_usage_cpu_core_seconds FROM pod_metrics WHERE pod_id = $1 AND timestamp = $2", podID, "2025-05-17 15:00:00+00").Scan(&podUsage)
-// 	// assert.NoError(t, err)
-// 	// assert.Equal(t, 200.0, podUsage, "pod_metrics should have usage for 15:00")
-// }
+	// Check pod_daily_summary - should have 2 unique hours
+	var podTotalHours int
+	var totalEffectiveCoreSeconds float64
+	err = pool.QueryRow(context.Background(),
+		"SELECT total_hours, total_pod_effective_core_seconds FROM pod_daily_summary WHERE pod_id = $1 AND date = $2",
+		podUUID, "2025-05-17").Scan(&podTotalHours, &totalEffectiveCoreSeconds)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, podTotalHours, "pod_daily_summary should have 2 unique hours")
+	// Hour 14:00: max(150, 250) = 250
+	// Hour 15:00: max(200, 300) = 300
+	// Total: 250 + 300 = 550
+	assert.Equal(t, 550.0, totalEffectiveCoreSeconds, "pod_daily_summary should sum effective core seconds (250 + 300)")
+
+	// Check pod_metrics for 14:00 - should have the values from the record
+	var podUsage, podRequest float64
+	err = pool.QueryRow(context.Background(),
+		"SELECT pod_usage_cpu_core_seconds, pod_request_cpu_core_seconds FROM pod_metrics WHERE pod_id = $1 AND timestamp = $2",
+		podUUID, "2025-05-17 14:00:00+00").Scan(&podUsage, &podRequest)
+	assert.NoError(t, err)
+	assert.Equal(t, 150.0, podUsage, "pod_metrics should have usage for 14:00")
+	assert.Equal(t, 250.0, podRequest, "pod_metrics should have request for 14:00")
+
+	// Check pod_metrics for 15:00
+	err = pool.QueryRow(context.Background(),
+		"SELECT pod_usage_cpu_core_seconds, pod_request_cpu_core_seconds FROM pod_metrics WHERE pod_id = $1 AND timestamp = $2",
+		podUUID, "2025-05-17 15:00:00+00").Scan(&podUsage, &podRequest)
+	assert.NoError(t, err)
+	assert.Equal(t, 200.0, podUsage, "pod_metrics should have usage for 15:00")
+	assert.Equal(t, 300.0, podRequest, "pod_metrics should have request for 15:00")
+}
 
 func TestProcessCSVInvalidTimestamp(t *testing.T) {
 	pool := testutils.SetupTestDB(t)
@@ -111,4 +137,130 @@ func TestProcessCSVMissingLabel(t *testing.T) {
 	err = pool.QueryRow(context.Background(), "SELECT COUNT(*) FROM pod_metrics").Scan(&count)
 	assert.NoError(t, err)
 	assert.Equal(t, 0, count, "No pod metrics should be inserted without matching label")
+}
+
+// Made with Bob 1.0.1
+// TestProcessCSVTotalHoursCount verifies that total_hours counts unique hours, not total records
+// This test reproduces the bug where 55 records would show 55 hours instead of the actual unique hours
+func TestProcessCSVTotalHoursCount(t *testing.T) {
+	pool := testutils.SetupTestDB(t)
+	repo := db.NewRepository(pool)
+	ctx := context.Background()
+
+	os.Setenv("POD_LABEL_KEYS", "label_rht_comp")
+	defer os.Unsetenv("POD_LABEL_KEYS")
+
+	clusterID := "10f5a0f9-223a-41c1-8456-9a3eb0323a99"
+	clusterUUID, _ := uuid.Parse(clusterID)
+
+	// Setup cluster
+	err := repo.UpsertCluster(clusterUUID, "test-cluster")
+	require.NoError(t, err)
+
+	// Create CSV with multiple records in the same hours
+	// Simulates the scenario: 1 pod, 3 unique hours, but 55 total records
+	// Hour 14:00 - 20 records
+	// Hour 15:00 - 20 records
+	// Hour 16:00 - 15 records
+	// Total: 55 records, but only 3 unique hours
+	csvBuilder := strings.Builder{}
+	csvBuilder.WriteString("report_period_start,report_period_end,interval_start,interval_end,node,namespace,pod,pod_usage_cpu_core_seconds,pod_request_cpu_core_seconds,pod_limit_cpu_core_seconds,pod_usage_memory_byte_seconds,pod_request_memory_byte_seconds,pod_limit_memory_byte_seconds,node_capacity_cpu_cores,node_capacity_cpu_core_seconds,node_capacity_memory_bytes,node_capacity_memory_byte_seconds,node_role,resource_id,pod_labels\n")
+
+	// Generate 20 records for hour 14:00
+	for i := 0; i < 20; i++ {
+		csvBuilder.WriteString("2025-05-17 00:00:00 +0000 UTC,2025-05-17 23:59:59 +0000 UTC,2025-05-17 14:00:00 +0000 UTC,2025-05-17 15:00:00 +0000 UTC,ip-10-0-1-63.ec2.internal,test,eap-pod-1,100,200,300,1000,2000,3000,4,14400,17179869184,61729433600,worker,i-09ad6102842b9a786,app:web|label_rht_comp:EAP\n")
+	}
+
+	// Generate 20 records for hour 15:00
+	for i := 0; i < 20; i++ {
+		csvBuilder.WriteString("2025-05-17 00:00:00 +0000 UTC,2025-05-17 23:59:59 +0000 UTC,2025-05-17 15:00:00 +0000 UTC,2025-05-17 16:00:00 +0000 UTC,ip-10-0-1-63.ec2.internal,test,eap-pod-1,150,250,350,1500,2500,3500,4,14400,17179869184,61729433600,worker,i-09ad6102842b9a786,app:web|label_rht_comp:EAP\n")
+	}
+
+	// Generate 15 records for hour 16:00
+	for i := 0; i < 15; i++ {
+		csvBuilder.WriteString("2025-05-17 00:00:00 +0000 UTC,2025-05-17 23:59:59 +0000 UTC,2025-05-17 16:00:00 +0000 UTC,2025-05-17 17:00:00 +0000 UTC,ip-10-0-1-63.ec2.internal,test,eap-pod-1,200,300,400,2000,3000,4000,4,14400,17179869184,61729433600,worker,i-09ad6102842b9a786,app:web|label_rht_comp:EAP\n")
+	}
+
+	reader := csv.NewReader(strings.NewReader(csvBuilder.String()))
+	err = ProcessCSV(ctx, repo, reader, clusterID)
+	assert.NoError(t, err)
+
+	// Query pod_daily_summary to check total_hours
+	var totalHours int
+	var totalPodEffectiveCoreSeconds float64
+	err = pool.QueryRow(context.Background(),
+		`SELECT total_hours, total_pod_effective_core_seconds 
+		 FROM pod_daily_summary pds
+		 JOIN pods p ON pds.pod_id = p.id
+		 WHERE p.name = $1 AND pds.date = $2`,
+		"eap-pod-1", "2025-05-17").Scan(&totalHours, &totalPodEffectiveCoreSeconds)
+
+	require.NoError(t, err, "Should find pod_daily_summary record")
+
+	// The fix: total_hours should be 3 (unique hours: 14:00, 15:00, 16:00)
+	// NOT 55 (total number of records)
+	assert.Equal(t, 3, totalHours, "total_hours should count unique hours (3), not total records (55)")
+
+	// Verify the aggregated core seconds are correct
+	// The new logic stores ONE metric per hour (not per record)
+	// Hour 14:00: max(usage=100, request=200) = 200
+	// Hour 15:00: max(usage=150, request=250) = 250
+	// Hour 16:00: max(usage=200, request=300) = 300
+	// Total: 200 + 250 + 300 = 750
+	expectedTotalCoreSeconds := 200.0 + 250.0 + 300.0
+	assert.InDelta(t, expectedTotalCoreSeconds, totalPodEffectiveCoreSeconds, 0.01,
+		"total_pod_effective_core_seconds should sum the effective core seconds for each unique hour")
+}
+
+// Made with Bob 1.0.1
+// TestProcessCSVMultipleDaysHours verifies total_hours across multiple days
+func TestProcessCSVMultipleDaysHours(t *testing.T) {
+	pool := testutils.SetupTestDB(t)
+	repo := db.NewRepository(pool)
+	ctx := context.Background()
+
+	os.Setenv("POD_LABEL_KEYS", "label_rht_comp")
+	defer os.Unsetenv("POD_LABEL_KEYS")
+
+	clusterID := "10f5a0f9-223a-41c1-8456-9a3eb0323a99"
+	clusterUUID, _ := uuid.Parse(clusterID)
+
+	err := repo.UpsertCluster(clusterUUID, "test-cluster")
+	require.NoError(t, err)
+
+	// CSV with data across 2 days
+	// Day 1 (May 17): 2 unique hours (14:00, 15:00) with 10 records each
+	// Day 2 (May 18): 3 unique hours (10:00, 11:00, 12:00) with 5 records each
+	csvData := `report_period_start,report_period_end,interval_start,interval_end,node,namespace,pod,pod_usage_cpu_core_seconds,pod_request_cpu_core_seconds,pod_limit_cpu_core_seconds,pod_usage_memory_byte_seconds,pod_request_memory_byte_seconds,pod_limit_memory_byte_seconds,node_capacity_cpu_cores,node_capacity_cpu_core_seconds,node_capacity_memory_bytes,node_capacity_memory_byte_seconds,node_role,resource_id,pod_labels
+2025-05-17 00:00:00 +0000 UTC,2025-05-17 23:59:59 +0000 UTC,2025-05-17 14:00:00 +0000 UTC,2025-05-17 15:00:00 +0000 UTC,node-1,test,pod-1,100,200,300,1000,2000,3000,4,14400,17179869184,61729433600,worker,i-123,label_rht_comp:EAP
+2025-05-17 00:00:00 +0000 UTC,2025-05-17 23:59:59 +0000 UTC,2025-05-17 14:00:00 +0000 UTC,2025-05-17 15:00:00 +0000 UTC,node-1,test,pod-1,100,200,300,1000,2000,3000,4,14400,17179869184,61729433600,worker,i-123,label_rht_comp:EAP
+2025-05-17 00:00:00 +0000 UTC,2025-05-17 23:59:59 +0000 UTC,2025-05-17 15:00:00 +0000 UTC,2025-05-17 16:00:00 +0000 UTC,node-1,test,pod-1,150,250,350,1500,2500,3500,4,14400,17179869184,61729433600,worker,i-123,label_rht_comp:EAP
+2025-05-17 00:00:00 +0000 UTC,2025-05-17 23:59:59 +0000 UTC,2025-05-17 15:00:00 +0000 UTC,2025-05-17 16:00:00 +0000 UTC,node-1,test,pod-1,150,250,350,1500,2500,3500,4,14400,17179869184,61729433600,worker,i-123,label_rht_comp:EAP
+2025-05-18 00:00:00 +0000 UTC,2025-05-18 23:59:59 +0000 UTC,2025-05-18 10:00:00 +0000 UTC,2025-05-18 11:00:00 +0000 UTC,node-1,test,pod-1,200,300,400,2000,3000,4000,4,14400,17179869184,61729433600,worker,i-123,label_rht_comp:EAP
+2025-05-18 00:00:00 +0000 UTC,2025-05-18 23:59:59 +0000 UTC,2025-05-18 11:00:00 +0000 UTC,2025-05-18 12:00:00 +0000 UTC,node-1,test,pod-1,250,350,450,2500,3500,4500,4,14400,17179869184,61729433600,worker,i-123,label_rht_comp:EAP
+2025-05-18 00:00:00 +0000 UTC,2025-05-18 23:59:59 +0000 UTC,2025-05-18 12:00:00 +0000 UTC,2025-05-18 13:00:00 +0000 UTC,node-1,test,pod-1,300,400,500,3000,4000,5000,4,14400,17179869184,61729433600,worker,i-123,label_rht_comp:EAP`
+
+	reader := csv.NewReader(strings.NewReader(csvData))
+	err = ProcessCSV(ctx, repo, reader, clusterID)
+	assert.NoError(t, err)
+
+	// Check Day 1 (May 17) - should have 2 unique hours
+	var day1Hours int
+	err = pool.QueryRow(context.Background(),
+		`SELECT total_hours FROM pod_daily_summary pds
+		 JOIN pods p ON pds.pod_id = p.id
+		 WHERE p.name = $1 AND pds.date = $2`,
+		"pod-1", "2025-05-17").Scan(&day1Hours)
+	require.NoError(t, err)
+	assert.Equal(t, 2, day1Hours, "Day 1 should have 2 unique hours (14:00, 15:00)")
+
+	// Check Day 2 (May 18) - should have 3 unique hours
+	var day2Hours int
+	err = pool.QueryRow(context.Background(),
+		`SELECT total_hours FROM pod_daily_summary pds
+		 JOIN pods p ON pds.pod_id = p.id
+		 WHERE p.name = $1 AND pds.date = $2`,
+		"pod-1", "2025-05-18").Scan(&day2Hours)
+	require.NoError(t, err)
+	assert.Equal(t, 3, day2Hours, "Day 2 should have 3 unique hours (10:00, 11:00, 12:00)")
 }

--- a/internal/processor/testutils/setup.go
+++ b/internal/processor/testutils/setup.go
@@ -5,14 +5,23 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/require"
 )
 
+// Global mutex to prevent concurrent schema setup across all tests
+var setupMutex sync.Mutex
+
 func SetupTestDB(t *testing.T) *pgxpool.Pool {
+	// Lock to prevent concurrent schema setup
+	setupMutex.Lock()
+	defer setupMutex.Unlock()
+
 	dbURL := "postgres://costmetrics:costmetrics@localhost:5432/costmetrics?sslmode=disable"
 	config, err := pgxpool.ParseConfig(dbURL)
 	require.NoError(t, err)
@@ -20,51 +29,73 @@ func SetupTestDB(t *testing.T) *pgxpool.Pool {
 	pool, err := pgxpool.NewWithConfig(context.Background(), config)
 	require.NoError(t, err)
 
-	tx, err := pool.Begin(context.Background())
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		tx.Rollback(context.Background())
-	})
+	// Check if schema exists by trying to query a table
+	var schemaExists bool
+	err = pool.QueryRow(context.Background(), "SELECT EXISTS (SELECT FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'clusters')").Scan(&schemaExists)
 
-	_, err = tx.Exec(context.Background(), `
-		DROP TABLE IF EXISTS pod_daily_summary, pod_metrics, pods, node_daily_summary, node_metrics, nodes, clusters CASCADE
-	`)
-	require.NoError(t, err)
+	if err != nil || !schemaExists {
+		// Drop and recreate schema completely to avoid type conflicts
+		_, err = pool.Exec(context.Background(), `
+			DROP SCHEMA IF EXISTS public CASCADE;
+			CREATE SCHEMA public;
+			GRANT ALL ON SCHEMA public TO costmetrics;
+			GRANT ALL ON SCHEMA public TO public;
+		`)
+		require.NoError(t, err)
 
-	_, currentFile, _, ok := runtime.Caller(0)
-	if !ok {
-		panic("Could not get caller information")
+		_, currentFile, _, ok := runtime.Caller(0)
+		if !ok {
+			panic("Could not get caller information")
+		}
+		currentDir := filepath.Dir(currentFile)
+
+		schemaPath := filepath.Join(currentDir, "..", "..", "db", "migrations", "0001_init.up.sql")
+		schema, err := os.ReadFile(schemaPath)
+		require.NoError(t, err)
+		_, err = pool.Exec(context.Background(), string(schema))
+		require.NoError(t, err)
+
+		// Create partition for May 2025 - all test data uses dates in this month (17, 18, 20)
+		_, err = pool.Exec(context.Background(), `
+			CREATE TABLE IF NOT EXISTS node_metrics_202505 PARTITION OF node_metrics
+			FOR VALUES FROM ('2025-05-01') TO ('2025-06-01');
+			CREATE TABLE IF NOT EXISTS pod_metrics_202505 PARTITION OF pod_metrics
+			FOR VALUES FROM ('2025-05-01') TO ('2025-06-01')
+		`)
+		require.NoError(t, err)
+	} else {
+		// Schema exists, clean up data from previous tests
+		_, err = pool.Exec(context.Background(), `
+			TRUNCATE TABLE pod_metrics CASCADE;
+			TRUNCATE TABLE node_metrics CASCADE;
+			TRUNCATE TABLE pod_daily_summary CASCADE;
+			TRUNCATE TABLE node_daily_summary CASCADE;
+			TRUNCATE TABLE pods CASCADE;
+			TRUNCATE TABLE nodes CASCADE;
+			TRUNCATE TABLE clusters CASCADE;
+		`)
+		require.NoError(t, err)
+		// Small delay to ensure cleanup completes
+		time.Sleep(50 * time.Millisecond)
 	}
-	currentDir := filepath.Dir(currentFile)
 
-	schemaPath := filepath.Join(currentDir, "..", "..", "db", "migrations", "0001_init.up.sql")
-	schema, err := os.ReadFile(schemaPath)
-	require.NoError(t, err)
-	_, err = tx.Exec(context.Background(), string(schema))
-	require.NoError(t, err)
-
+	// Insert test cluster and node for each test
 	clusterID, _ := uuid.Parse("10f5a0f9-223a-41c1-8456-9a3eb0323a99")
-	_, err = tx.Exec(context.Background(), `
+	_, err = pool.Exec(context.Background(), `
 		INSERT INTO clusters (id, name) VALUES ($1, 'test-cluster')
+		ON CONFLICT (id) DO NOTHING
 	`, clusterID)
 	require.NoError(t, err)
 
+	// Small delay to ensure cluster insert completes
+	time.Sleep(100 * time.Millisecond)
+
 	nodeID, _ := uuid.Parse("fba4e7cd-4ee2-4f24-880d-082eb2b41128")
-	_, err = tx.Exec(context.Background(), `
+	_, err = pool.Exec(context.Background(), `
 		INSERT INTO nodes (id, cluster_id, name, identifier, type)
 		VALUES ($1, $2, 'ip-10-0-1-63.ec2.internal', 'i-09ad6102842b9a786', 'worker')
+		ON CONFLICT (identifier) DO NOTHING
 	`, nodeID, clusterID)
-	require.NoError(t, err)
-
-	_, err = tx.Exec(context.Background(), `
-		CREATE TABLE node_metrics_202505 PARTITION OF node_metrics
-		FOR VALUES FROM ('2025-05-01') TO ('2025-06-01');
-		CREATE TABLE pod_metrics_202505 PARTITION OF pod_metrics
-		FOR VALUES FROM ('2025-05-01') TO ('2025-06-01')
-	`)
-	require.NoError(t, err)
-
-	err = tx.Commit(context.Background())
 	require.NoError(t, err)
 
 	t.Cleanup(func() {


### PR DESCRIPTION
This PR was written with assistance from Bob v1.0.0 and v1.0.1.

There were instances where incoming reports were causing the aggregator to double count. For example, running the applications for 8 hours was resulting in 16+ hours being reported by the Aggregator, and the CPU values didn't line-up with what I was observing through PromQL.

The following commits remove the duplication, and add unit tests to verify.