### PR TITLE
fix(build): update ubi9/go-toolset to 1.25

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM registry.access.redhat.com/ubi9/go-toolset:1.23 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25 AS builder
 
 # Set working directory
 WORKDIR /app


### PR DESCRIPTION
Bumped the go version, but forgot to update the ubi9 version in the Containerfile