### PR TITLE
fix(processor): fix empty cpu usage values

### DIFF
--- a/internal/processor/csv_processor.go
+++ b/internal/processor/csv_processor.go
@@ -132,8 +132,14 @@ func ProcessCSV(ctx context.Context, repo *db.Repository, reader *csv.Reader, cl
 
 		podUsage, err := strconv.ParseFloat(podUsageStr, 64)
 		if err != nil {
-			log.Printf("Skipping record %d: invalid pod_usage_cpu_core_seconds %s: %v", i+1, podUsageStr, err)
-			continue
+			// Allow empty pod_usage_cpu_core_seconds, default to 0.0
+			if podUsageStr == "" {
+				log.Printf("Record %d: empty pod_usage_cpu_core_seconds - setting to 0.0", i+1)
+				podUsage = 0.0
+			} else {
+				log.Printf("Skipping record %d: invalid pod_usage_cpu_core_seconds %s: %v", i+1, podUsageStr, err)
+				continue
+			}
 		}
 
 		podRequest, err := strconv.ParseFloat(podRequestStr, 64)


### PR DESCRIPTION
I'm seeing some warnings:
```
2026/04/23 15:14:14 Processing record 213: [2026-04-01 00:00:00 +0000 UTC 2026-05-01 00:00:00 +0000 UTC 2026-04-23 14:00:00 +0000 UTC 2026-04-23 14:59:59 +0000 UTC crc openshift-operator-lifecycle-manager collect-profiles-29615850-2n7rh 0.000000 0.000000 12.000000 43200.000000 53446742016.000000 192408271257600.000000 worker label_batch_kubernetes_io_controller_uid:b373376f-5f70-4a5b-8e29-e4d0b48c8dff|label_batch_kubernetes_io_job_name:collect-profiles-29615850|label_controller_uid:b373376f-5f70-4a5b-8e29-e4d0b48c8dff|label_job_name:collect-profiles-29615850]
2026/04/23 15:14:14 Skipping record 213: invalid pod_usage_cpu_core_seconds : strconv.ParseFloat: parsing "": invalid syntax
```

The csv processor doesn't handle empty cpu core second values, so we can just default those values to 0.
